### PR TITLE
Bump to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustacuda"
 version = "0.1.0"
 authors = ["Brook Heisler <brookheisler@gmail.com>"]
+edition = "2018"
 
 description = "CUDA Driver API Wrapper"
 repository = "https://github.com/bheisler/RustaCUDA"

--- a/rustacuda_core/Cargo.toml
+++ b/rustacuda_core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustacuda_core"
 version = "0.1.0"
 authors = ["Brook Heisler <brookheisler@gmail.com>"]
+edition = "2018"
 
 description = "Minimal kernel-support crate for Rustacuda"
 repository = "https://github.com/bheisler/RustaCUDA"

--- a/rustacuda_core/src/lib.rs
+++ b/rustacuda_core/src/lib.rs
@@ -15,4 +15,4 @@
 #![allow(unknown_lints)]
 
 mod memory;
-pub use memory::*;
+pub use crate::memory::*;

--- a/rustacuda_core/src/memory/mod.rs
+++ b/rustacuda_core/src/memory/mod.rs
@@ -94,7 +94,7 @@ macro_rules! impl_device_copy_array {
     }
 }
 
-impl_device_copy_array!{
+impl_device_copy_array! {
     1 2 3 4 5 6 7 8 9 10
     11 12 13 14 15 16 17 18 19 20
     21 22 23 24 25 26 27 28 29 30
@@ -105,13 +105,16 @@ unsafe impl<A: DeviceCopy, B: DeviceCopy> DeviceCopy for (A, B) {}
 unsafe impl<A: DeviceCopy, B: DeviceCopy, C: DeviceCopy> DeviceCopy for (A, B, C) {}
 unsafe impl<A: DeviceCopy, B: DeviceCopy, C: DeviceCopy, D: DeviceCopy> DeviceCopy
     for (A, B, C, D)
-{}
+{
+}
 unsafe impl<A: DeviceCopy, B: DeviceCopy, C: DeviceCopy, D: DeviceCopy, E: DeviceCopy> DeviceCopy
     for (A, B, C, D, E)
-{}
+{
+}
 unsafe impl<A: DeviceCopy, B: DeviceCopy, C: DeviceCopy, D: DeviceCopy, E: DeviceCopy, F: DeviceCopy>
     DeviceCopy for (A, B, C, D, E, F)
-{}
+{
+}
 unsafe impl<
         A: DeviceCopy,
         B: DeviceCopy,
@@ -121,7 +124,8 @@ unsafe impl<
         F: DeviceCopy,
         G: DeviceCopy,
     > DeviceCopy for (A, B, C, D, E, F, G)
-{}
+{
+}
 unsafe impl<
         A: DeviceCopy,
         B: DeviceCopy,
@@ -132,4 +136,5 @@ unsafe impl<
         G: DeviceCopy,
         H: DeviceCopy,
     > DeviceCopy for (A, B, C, D, E, F, G, H)
-{}
+{
+}

--- a/rustacuda_core/src/memory/pointer.rs
+++ b/rustacuda_core/src/memory/pointer.rs
@@ -1,6 +1,6 @@
+use crate::memory::DeviceCopy;
 use core::fmt;
 use core::ptr;
-use memory::DeviceCopy;
 
 /// A pointer to device memory.
 ///
@@ -211,7 +211,7 @@ impl<T> DevicePointer<T> {
     ///     cuda_free(dev_ptr); // Must free the buffer using the original pointer
     /// }
     /// ```
-    #[allow(should_implement_trait)]
+    #[allow(clippy::should_implement_trait)]
     pub unsafe fn add(self, count: usize) -> Self
     where
         T: Sized,
@@ -252,7 +252,7 @@ impl<T> DevicePointer<T> {
     ///     let offset = dev_ptr.add(4).sub(3); // Points to the 2nd u64 in the buffer
     ///     cuda_free(dev_ptr); // Must free the buffer using the original pointer
     /// }
-    #[allow(should_implement_trait)]
+    #[allow(clippy::should_implement_trait)]
     pub unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,
@@ -544,7 +544,7 @@ impl<T: DeviceCopy> UnifiedPointer<T> {
     ///     cuda_free_unified(unified_ptr); // Must free the buffer using the original pointer
     /// }
     /// ```
-    #[allow(should_implement_trait)]
+    #[allow(clippy::should_implement_trait)]
     pub unsafe fn add(self, count: usize) -> Self
     where
         T: Sized,
@@ -585,7 +585,7 @@ impl<T: DeviceCopy> UnifiedPointer<T> {
     ///     let offset = unified_ptr.add(4).sub(3); // Points to the 2nd u64 in the buffer
     ///     cuda_free_unified(unified_ptr); // Must free the buffer using the original pointer
     /// }
-    #[allow(should_implement_trait)]
+    #[allow(clippy::should_implement_trait)]
     pub unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,

--- a/rustacuda_derive/Cargo.toml
+++ b/rustacuda_derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustacuda_derive"
 version = "0.1.0"
 authors = ["Brook Heisler <brookheisler@gmail.com>"]
+edition = "2018"
 
 description = "Custom Derive Macro for RustaCUDA"
 repository = "https://github.com/bheisler/RustaCUDA"

--- a/rustacuda_derive/src/lib.rs
+++ b/rustacuda_derive/src/lib.rs
@@ -46,7 +46,7 @@ fn impl_device_copy(input: &DeriveInput) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
     // Finally, generate the unsafe impl and the type-checking function.
-    let generated_code = quote!{
+    let generated_code = quote! {
         unsafe impl#impl_generics ::rustacuda_core::DeviceCopy for #input_type#type_generics #where_clause {}
 
         #[doc(hidden)]
@@ -63,7 +63,7 @@ fn impl_device_copy(input: &DeriveInput) -> TokenStream {
 fn add_bound_to_generics(generics: &Generics) -> Generics {
     let mut new_generics = generics.clone();
     let bound: TypeParamBound =
-        parse_str(&quote!{::rustacuda_core::DeviceCopy}.to_string()).unwrap();
+        parse_str(&quote! {::rustacuda_core::DeviceCopy}.to_string()).unwrap();
 
     for type_param in &mut new_generics.type_params_mut() {
         type_param.bounds.push(bound.clone())
@@ -123,6 +123,7 @@ fn check_fields(fields: &Vec<&Field>) -> Vec<TokenStream> {
         .iter()
         .map(|field| {
             let field_type = &field.ty;
-            quote!{assert_impl::<#field_type>();}
-        }).collect()
+            quote! {assert_impl::<#field_type>();}
+        })
+        .collect()
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -103,14 +103,14 @@
 //! // Call RustaCUDA functions which use the context
 //! ```
 
+use crate::device::Device;
+use crate::error::{CudaResult, DropResult, ToResult};
+use crate::private::Sealed;
+use crate::CudaApiVersion;
 use cuda_sys::cuda::{self, CUcontext};
-use device::Device;
-use error::{CudaResult, DropResult, ToResult};
-use private::Sealed;
 use std::mem;
 use std::mem::transmute;
 use std::ptr;
-use CudaApiVersion;
 
 /// This enumeration represents configuration settings for devices which share hardware resources
 /// between L1 cache and shared memory.
@@ -254,7 +254,8 @@ impl Context {
                 &mut ctx as *mut CUcontext,
                 flags.bits(),
                 device.into_inner(),
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(Context { inner: ctx })
         }
     }
@@ -595,7 +596,8 @@ impl CurrentContext {
             let mut cfg = SharedMemoryConfig::DefaultBankSize;
             cuda::cuCtxGetSharedMemConfig(
                 &mut cfg as *mut SharedMemoryConfig as *mut cuda::CUsharedconfig,
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(cfg)
         }
     }
@@ -627,7 +629,8 @@ impl CurrentContext {
             cuda::cuCtxGetStreamPriorityRange(
                 &mut range.least as *mut i32,
                 &mut range.greatest as *mut i32,
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(range)
         }
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,7 @@
 //! Functions and types for enumerating CUDA devices and retrieving information about them.
 
+use crate::error::{CudaResult, ToResult};
 use cuda_sys::cuda::*;
-use error::{CudaResult, ToResult};
 use std::ffi::CStr;
 use std::ops::Range;
 
@@ -317,7 +317,8 @@ impl Device {
                 // This should be safe, as the repr and values of DeviceAttribute should match.
                 ::std::mem::transmute(attr),
                 self.device,
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(val)
         }
     }
@@ -346,7 +347,7 @@ mod test {
     use super::*;
 
     fn test_init() {
-        ::init(::CudaFlags::empty()).unwrap();
+        crate::init(crate::CudaFlags::empty()).unwrap();
     }
 
     #[test]

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,9 +1,9 @@
 //! Functions and types for working with CUDA kernels.
 
-use context::{CacheConfig, SharedMemoryConfig};
+use crate::context::{CacheConfig, SharedMemoryConfig};
+use crate::error::{CudaResult, ToResult};
+use crate::module::Module;
 use cuda_sys::cuda::{self, CUfunction};
-use error::{CudaResult, ToResult};
-use module::Module;
 use std::marker::PhantomData;
 use std::mem::transmute;
 
@@ -192,7 +192,8 @@ impl<'a> Function<'a> {
                 // This should be safe, as the repr and values of FunctionAttribute should match.
                 ::std::mem::transmute(attr),
                 self.inner,
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(val)
         }
     }
@@ -400,11 +401,11 @@ macro_rules! launch {
 #[cfg(test)]
 mod test {
     use super::*;
-    use memory::CopyDestination;
-    use memory::DeviceBuffer;
-    use quick_init;
+    use crate::memory::CopyDestination;
+    use crate::memory::DeviceBuffer;
+    use crate::quick_init;
+    use crate::stream::{Stream, StreamFlags};
     use std::ffi::CString;
-    use stream::{Stream, StreamFlags};
 
     #[test]
     fn test_launch() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,14 +148,14 @@
 // TODO: Add the missing_doc_code_examples warning, switch these to Deny later.
 
 // Allow clippy lints
-#![allow(unknown_lints)]
+#![allow(unknown_lints, clippy::new_ret_no_self)]
 
 #[macro_use]
 extern crate bitflags;
 extern crate cuda_sys;
 extern crate rustacuda_core;
 
-#[allow(unused_imports, useless_attribute)]
+#[allow(unused_imports, clippy::useless_attribute)]
 #[macro_use]
 extern crate rustacuda_derive;
 #[doc(hidden)]
@@ -172,10 +172,10 @@ pub mod stream;
 
 mod derive_compile_fail;
 
-use context::{Context, ContextFlags};
+use crate::context::{Context, ContextFlags};
+use crate::device::Device;
+use crate::error::{CudaResult, ToResult};
 use cuda_sys::cuda::{cuDriverGetVersion, cuInit};
-use device::Device;
-use error::{CudaResult, ToResult};
 
 bitflags! {
     /// Bit flags for initializing the CUDA driver. Currently, no flags are defined,

--- a/src/memory/locked.rs
+++ b/src/memory/locked.rs
@@ -1,6 +1,6 @@
 use super::DeviceCopy;
-use error::*;
-use memory::malloc::{cuda_free_locked, cuda_malloc_locked};
+use crate::error::*;
+use crate::memory::malloc::{cuda_free_locked, cuda_malloc_locked};
 use std::mem;
 use std::ops;
 use std::ptr;
@@ -278,11 +278,11 @@ mod test {
 
     #[derive(Clone, Debug)]
     struct ZeroSizedType;
-    unsafe impl ::memory::DeviceCopy for ZeroSizedType {}
+    unsafe impl DeviceCopy for ZeroSizedType {}
 
     #[test]
     fn test_new() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let val = 0u64;
         let mut buffer = LockedBuffer::new(&val, 5).unwrap();
         buffer[0] = 1;
@@ -290,7 +290,7 @@ mod test {
 
     #[test]
     fn test_from_slice() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let values = [0u64; 10];
         let mut buffer = LockedBuffer::from_slice(&values).unwrap();
         for i in buffer[0..3].iter_mut() {
@@ -300,7 +300,7 @@ mod test {
 
     #[test]
     fn from_raw_parts() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let mut buffer = LockedBuffer::new(&0u64, 5).unwrap();
         buffer[2] = 1;
         let ptr = buffer.as_mut_ptr();
@@ -314,21 +314,21 @@ mod test {
 
     #[test]
     fn zero_length_buffer() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let buffer = LockedBuffer::new(&0u64, 0).unwrap();
         drop(buffer);
     }
 
     #[test]
     fn zero_size_type() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let buffer = LockedBuffer::new(&ZeroSizedType, 10).unwrap();
         drop(buffer);
     }
 
     #[test]
     fn overflows_usize() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let err = LockedBuffer::new(&0u64, ::std::usize::MAX - 1).unwrap_err();
         assert_eq!(CudaError::InvalidMemoryAllocation, err);
     }

--- a/src/memory/malloc.rs
+++ b/src/memory/malloc.rs
@@ -1,8 +1,8 @@
 use super::DeviceCopy;
+use crate::error::*;
+use crate::memory::DevicePointer;
+use crate::memory::UnifiedPointer;
 use cuda_sys::cuda;
-use error::*;
-use memory::DevicePointer;
-use memory::UnifiedPointer;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
@@ -94,7 +94,8 @@ pub unsafe fn cuda_malloc_unified<T: DeviceCopy>(count: usize) -> CudaResult<Uni
         &mut ptr as *mut *mut c_void as *mut u64,
         size,
         cuda::CUmemAttach_flags_enum::CU_MEM_ATTACH_GLOBAL as u32,
-    ).to_result()?;
+    )
+    .to_result()?;
     let ptr = ptr as *mut T;
     Ok(UnifiedPointer::wrap(ptr as *mut T))
 }
@@ -246,11 +247,11 @@ mod test {
 
     #[derive(Clone, Debug)]
     struct ZeroSizedType;
-    unsafe impl ::memory::DeviceCopy for ZeroSizedType {}
+    unsafe impl DeviceCopy for ZeroSizedType {}
 
     #[test]
     fn test_cuda_malloc() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             let device_mem = cuda_malloc::<u64>(1).unwrap();
             assert!(!device_mem.is_null());
@@ -260,7 +261,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_zero_bytes() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -271,7 +272,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_zero_sized() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -282,7 +283,7 @@ mod test {
 
     #[test]
     fn test_cuda_alloc_overflow() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -293,7 +294,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_unified() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             let mut unified = cuda_malloc_unified::<u64>(1).unwrap();
             assert!(!unified.is_null());
@@ -307,7 +308,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_unified_zero_bytes() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -318,7 +319,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_unified_zero_sized() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -329,7 +330,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_unified_overflow() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -340,7 +341,7 @@ mod test {
 
     #[test]
     fn test_cuda_free_null() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let null = ::std::ptr::null_mut::<u64>();
         unsafe {
             assert_eq!(
@@ -352,7 +353,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_locked() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             let locked = cuda_malloc_locked::<u64>(1).unwrap();
             assert!(!locked.is_null());
@@ -366,7 +367,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_locked_zero_bytes() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -377,7 +378,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_locked_zero_sized() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -388,7 +389,7 @@ mod test {
 
     #[test]
     fn test_cuda_malloc_locked_overflow() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,
@@ -399,7 +400,7 @@ mod test {
 
     #[test]
     fn test_cuda_free_locked_null() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         unsafe {
             assert_eq!(
                 CudaError::InvalidMemoryAllocation,

--- a/src/memory/unified.rs
+++ b/src/memory/unified.rs
@@ -1,7 +1,7 @@
 use super::DeviceCopy;
-use error::*;
-use memory::malloc::{cuda_free_unified, cuda_malloc_unified};
-use memory::UnifiedPointer;
+use crate::error::*;
+use crate::memory::malloc::{cuda_free_unified, cuda_malloc_unified};
+use crate::memory::UnifiedPointer;
 use std::borrow::{Borrow, BorrowMut};
 use std::cmp::Ordering;
 use std::convert::{AsMut, AsRef};
@@ -155,7 +155,7 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     /// let ptr = UnifiedBox::into_unified(x);
     /// # unsafe { UnifiedBox::from_unified(ptr) };
     /// ```
-    #[allow(wrong_self_convention)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_unified(mut b: UnifiedBox<T>) -> UnifiedPointer<T> {
         let ptr = mem::replace(&mut b.ptr, UnifiedPointer::null());
         mem::forget(b);
@@ -602,11 +602,11 @@ mod test_unified_box {
 
     #[derive(Clone, Debug)]
     struct ZeroSizedType;
-    unsafe impl ::memory::DeviceCopy for ZeroSizedType {}
+    unsafe impl DeviceCopy for ZeroSizedType {}
 
     #[test]
     fn test_allocate_and_free() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let mut x = UnifiedBox::new(5u64).unwrap();
         *x = 10;
         assert_eq!(10, *x);
@@ -615,7 +615,7 @@ mod test_unified_box {
 
     #[test]
     fn test_allocates_for_non_zst() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let x = UnifiedBox::new(5u64).unwrap();
         let ptr = UnifiedBox::into_unified(x);
         assert!(!ptr.is_null());
@@ -624,7 +624,7 @@ mod test_unified_box {
 
     #[test]
     fn test_doesnt_allocate_for_zero_sized_type() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let x = UnifiedBox::new(ZeroSizedType).unwrap();
         let ptr = UnifiedBox::into_unified(x);
         assert!(ptr.is_null());
@@ -633,7 +633,7 @@ mod test_unified_box {
 
     #[test]
     fn test_into_from_unified() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let x = UnifiedBox::new(5u64).unwrap();
         let ptr = UnifiedBox::into_unified(x);
         let _ = unsafe { UnifiedBox::from_unified(ptr) };
@@ -641,7 +641,7 @@ mod test_unified_box {
 
     #[test]
     fn test_equality() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let x = UnifiedBox::new(5u64).unwrap();
         let y = UnifiedBox::new(5u64).unwrap();
         let z = UnifiedBox::new(0u64).unwrap();
@@ -651,7 +651,7 @@ mod test_unified_box {
 
     #[test]
     fn test_ordering() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let x = UnifiedBox::new(1u64).unwrap();
         let y = UnifiedBox::new(2u64).unwrap();
 
@@ -665,11 +665,11 @@ mod test_unified_buffer {
 
     #[derive(Clone, Debug)]
     struct ZeroSizedType;
-    unsafe impl ::memory::DeviceCopy for ZeroSizedType {}
+    unsafe impl DeviceCopy for ZeroSizedType {}
 
     #[test]
     fn test_new() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let val = 0u64;
         let mut buffer = UnifiedBuffer::new(&val, 5).unwrap();
         buffer[0] = 1;
@@ -677,7 +677,7 @@ mod test_unified_buffer {
 
     #[test]
     fn test_from_slice() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let values = [0u64; 10];
         let mut buffer = UnifiedBuffer::from_slice(&values).unwrap();
         for i in buffer[0..3].iter_mut() {
@@ -687,7 +687,7 @@ mod test_unified_buffer {
 
     #[test]
     fn from_raw_parts() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let mut buffer = UnifiedBuffer::new(&0u64, 5).unwrap();
         buffer[2] = 1;
         let ptr = buffer.as_unified_ptr();
@@ -701,21 +701,21 @@ mod test_unified_buffer {
 
     #[test]
     fn zero_length_buffer() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let buffer = UnifiedBuffer::new(&0u64, 0).unwrap();
         drop(buffer);
     }
 
     #[test]
     fn zero_size_type() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let buffer = UnifiedBuffer::new(&ZeroSizedType, 10).unwrap();
         drop(buffer);
     }
 
     #[test]
     fn overflows_usize() {
-        let _context = ::quick_init().unwrap();
+        let _context = crate::quick_init().unwrap();
         let err = UnifiedBuffer::new(&0u64, ::std::usize::MAX - 1).unwrap_err();
         assert_eq!(CudaError::InvalidMemoryAllocation, err);
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,9 +1,9 @@
 //! Functions and types for working with CUDA modules.
 
+use crate::error::{CudaResult, DropResult, ToResult};
+use crate::function::Function;
+use crate::memory::{CopyDestination, DeviceCopy, DevicePointer};
 use cuda_sys::cuda;
-use error::{CudaResult, DropResult, ToResult};
-use function::Function;
-use memory::{CopyDestination, DeviceCopy, DevicePointer};
 use std::ffi::{c_void, CStr};
 use std::fmt;
 use std::marker::PhantomData;
@@ -70,7 +70,8 @@ impl Module {
             cuda::cuModuleLoadData(
                 &mut module.inner as *mut cuda::CUmodule,
                 image.as_ptr() as *const c_void,
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(module)
         }
     }
@@ -108,7 +109,8 @@ impl Module {
                 &mut size as *mut usize,
                 self.inner,
                 name.as_ptr(),
-            ).to_result()?;
+            )
+            .to_result()?;
             assert_eq!(size, mem::size_of::<T>());
             Ok(Symbol {
                 ptr,
@@ -140,7 +142,8 @@ impl Module {
                 &mut func as *mut cuda::CUfunction,
                 self.inner,
                 name.as_ptr(),
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(Function::new(func, self))
         }
     }
@@ -206,7 +209,7 @@ pub struct Symbol<'a, T: DeviceCopy> {
     ptr: DevicePointer<T>,
     module: PhantomData<&'a Module>,
 }
-impl<'a, T: DeviceCopy> ::private::Sealed for Symbol<'a, T> {}
+impl<'a, T: DeviceCopy> crate::private::Sealed for Symbol<'a, T> {}
 impl<'a, T: DeviceCopy> fmt::Pointer for Symbol<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Pointer::fmt(&self.ptr, f)
@@ -221,7 +224,8 @@ impl<'a, T: DeviceCopy> CopyDestination<T> for Symbol<'a, T> {
                     self.ptr.as_raw_mut() as u64,
                     val as *const T as *const c_void,
                     size,
-                ).to_result()?
+                )
+                .to_result()?
             }
         }
         Ok(())
@@ -235,7 +239,8 @@ impl<'a, T: DeviceCopy> CopyDestination<T> for Symbol<'a, T> {
                     val as *const T as *mut c_void,
                     self.ptr.as_raw() as u64,
                     size,
-                ).to_result()?
+                )
+                .to_result()?
             }
         }
         Ok(())
@@ -245,7 +250,7 @@ impl<'a, T: DeviceCopy> CopyDestination<T> for Symbol<'a, T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use quick_init;
+    use crate::quick_init;
     use std::ffi::CString;
 
     #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,9 +3,9 @@
 //! This allows the user to `use rustacuda::prelude::*;` and have the most commonly-used types
 //! available quickly.
 
-pub use context::{Context, ContextFlags};
-pub use device::Device;
-pub use memory::{CopyDestination, DeviceBuffer, UnifiedBuffer};
-pub use module::Module;
-pub use stream::{Stream, StreamFlags};
-pub use CudaFlags;
+pub use crate::context::{Context, ContextFlags};
+pub use crate::device::Device;
+pub use crate::memory::{CopyDestination, DeviceBuffer, UnifiedBuffer};
+pub use crate::module::Module;
+pub use crate::stream::{Stream, StreamFlags};
+pub use crate::CudaFlags;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -10,9 +10,9 @@
 //! are not currently supported by RustaCUDA. Finally, the host can wait for all work scheduled in
 //! a stream to be completed.
 
+use crate::error::{CudaResult, DropResult, ToResult};
+use crate::function::{BlockSize, Function, GridSize};
 use cuda_sys::cuda::{self, cudaError_t, CUstream};
-use error::{CudaResult, DropResult, ToResult};
-use function::{BlockSize, Function, GridSize};
 use std::ffi::c_void;
 use std::mem;
 use std::panic;
@@ -68,7 +68,7 @@ impl Stream {
     /// // With specific priority
     /// let priority = Stream::new(StreamFlags::NON_BLOCKING, 1i32.into()).unwrap();
     /// ```
-    pub fn new(flags: StreamFlags, priority: Option<i32>) -> CudaResult<Stream> {
+    pub fn new(flags: StreamFlags, priority: Option<i32>) -> CudaResult<Self> {
         unsafe {
             let mut stream = Stream {
                 inner: ptr::null_mut(),
@@ -77,7 +77,8 @@ impl Stream {
                 &mut stream.inner as *mut CUstream,
                 flags.bits(),
                 priority.unwrap_or(0),
-            ).to_result()?;
+            )
+            .to_result()?;
             Ok(stream)
         }
     }
@@ -164,7 +165,8 @@ impl Stream {
                 Some(callback_wrapper::<T>),
                 Box::into_raw(callback) as *mut c_void,
                 0,
-            ).to_result()
+            )
+            .to_result()
         }
     }
 
@@ -219,7 +221,8 @@ impl Stream {
             self.inner,
             args.as_ptr() as *mut _,
             ptr::null_mut(),
-        ).to_result()
+        )
+        .to_result()
     }
 
     /// Destroy a `Stream`, returning an error.

--- a/tests/test_stream.rs
+++ b/tests/test_stream.rs
@@ -13,15 +13,18 @@ fn test_stream_callbacks_execution_order() {
     stream
         .add_callback(Box::new(|_| {
             order_sender.send(1).unwrap();
-        })).unwrap();
+        }))
+        .unwrap();
     stream
         .add_callback(Box::new(|_| {
             order_sender.send(2).unwrap();
-        })).unwrap();
+        }))
+        .unwrap();
     stream
         .add_callback(Box::new(|_| {
             order_sender.send(3).unwrap();
-        })).unwrap();
+        }))
+        .unwrap();
     for expected in &[1, 2, 3] {
         assert_eq!(*expected, order_receiver.recv().unwrap());
     }
@@ -37,7 +40,8 @@ fn test_stream_callbacks_environment_capture() {
     stream
         .add_callback(Box::new(|_| {
             capture_sender.send(magic_numbers).unwrap();
-        })).unwrap();
+        }))
+        .unwrap();
     let captured_magic_numbers = capture_receiver.recv().unwrap();
     assert_eq!(42, captured_magic_numbers.0);
     assert_eq!(1337, *captured_magic_numbers.1);
@@ -52,6 +56,7 @@ fn test_stream_callbacks_status_propagation() {
     stream
         .add_callback(Box::new(|status| {
             status_sender.send(status).unwrap();
-        })).unwrap();
+        }))
+        .unwrap();
     assert_eq!(Ok(()), status_receiver.recv().unwrap())
 }


### PR DESCRIPTION
Use cargo fix --edition to bump to Rust 2018 with a few extra linter fixes too.