### PR TITLE
Implement unsafe async interface

### DIFF
--- a/src/memory/device/mod.rs
+++ b/src/memory/device/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::CudaResult;
+use crate::stream::Stream;
 
 mod device_box;
 mod device_buffer;
@@ -24,4 +25,42 @@ pub trait CopyDestination<O: ?Sized>: crate::private::Sealed {
     ///
     /// If a CUDA error occurs, return the error.
     fn copy_to(&self, dest: &mut O) -> CudaResult<()>;
+}
+
+/// Sealed trait implemented by types which can be the source or destination when copying data
+/// asynchronously to/from the device or from one device allocation to another.
+///
+/// ## Safety:
+///
+/// The fuctions of this trait are unsafe, as these functions return while the copying
+/// from source to destination is likely still taking place in the background, allowing
+/// the source and destination arguments to be potentially used in unsafe ways.
+///
+/// Thus to enforce safety, the following invariants should be enforced:
+/// * The source and destination are not deallocated
+/// * The source is read-only
+/// * The destination is not written or read by any other operation
+///
+pub trait AsyncCopyDestination<O: ?Sized>: crate::private::Sealed {
+    /// Asynchronously copy data from `source`. `source` must be the same size as `self`.
+    ///
+    /// Host memory used as a source or destination must be page-locked.
+    ///
+    /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
+    ///
+    /// # Errors:
+    ///
+    /// If a CUDA error occurs, return the error.
+    unsafe fn async_copy_from(&mut self, source: &O, stream: &Stream) -> CudaResult<()>;
+
+    /// Asynchronously copy data to `dest`. `dest` must be the same size as `self`.
+    ///
+    /// Host memory used as a source or destination must be page-locked.
+    ///
+    /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
+    ///
+    /// # Errors:
+    ///
+    /// If a CUDA error occurs, return the error.
+    unsafe fn async_copy_to(&self, dest: &mut O, stream: &Stream) -> CudaResult<()>;
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -244,6 +244,14 @@ impl Stream {
         .to_result()
     }
 
+    // Get the inner `CUstream` from the `Stream`.
+    //
+    // Necessary for certain CUDA functions outside of this
+    // module that expect a bare `CUstream`.
+    pub(crate) fn as_inner(&self) -> CUstream {
+        self.inner
+    }
+
     /// Destroy a `Stream`, returning an error.
     ///
     /// Destroying a stream can return errors from previous asynchronous work. This function


### PR DESCRIPTION
WIP still.

This is about what I need before wrapping these async functions safer in Futures. Additionally, I could see certain users of the libraries finding having the unsafe versions useful for performance or doing some other form of higher level safe interface. 

Current major issue is that it appears I might suspicions about the pinned memory issue might have been correct, as the `device_to_host` test only works consistently correctly copying to a `cudaHostMalloc` buffer. The heap allocated one then works slightly more than the stack allocated test. 

If this is the case, then we'll need to write up wrappers around `cudaHostMalloc` and enforce the usage of this pinned memory for async transfers.

Finally, the async functions need some way of obtaining `stream.inner`. The current hack that I did of making it public shouldn't stay. Instead, I'm thinking making `stream.inner` public to the crate and then passing &Stream references to async memcpy functions is the way to go.