### PR TITLE
Support Creation and Management of CUDA Arrays in RustaCUDA

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -111,11 +111,11 @@ pub enum DeviceAttribute {
     /// Pitch alignment requirement for textures
     TexturePitchAlignment = 51,
     /// Maximum cubemap texture width/height
-    MaximumTexturecubemapWidth = 52,
+    MaximumTextureCubemapWidth = 52,
     /// Maximum cubemap layered texture width/height
-    MaximumTexturecubemapLayeredWidth = 53,
+    MaximumTextureCubemapLayeredWidth = 53,
     /// Maximum layers in a cubemap layered texture
-    MaximumTexturecubemapLayeredLayers = 54,
+    MaximumTextureCubemapLayeredLayers = 54,
     /// Maximum 1D surface width
     MaximumSurface1DWidth = 55,
     /// Maximum 2D surface width

--- a/src/memory/array.rs
+++ b/src/memory/array.rs
@@ -1,7 +1,14 @@
+//! Routines for allocating and using CUDA Array Objects.
+//!
+//! Detailed documentation about allocating CUDA Arrays can be found in the
+//! [CUDA Driver API](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1gc2322c70b38c2984536c90ed118bb1d7)
+
 use std::os::raw::c_uint;
 
 use cuda_sys::cuda::{CUarray, CUarray_format, CUarray_format_enum};
 
+use crate::context::CurrentContext;
+use crate::device::DeviceAttribute;
 use crate::error::*;
 
 /// Describes the format used for a CUDA Array.
@@ -59,7 +66,7 @@ bitflags! {
     /// Flags which modify the behavior of CUDA array creation.
     #[derive(Default)]
     pub struct ArrayObjectFlags: c_uint {
-        /// Enables creation of layered CUDA array.s When this flag is set, depth specifies the
+        /// Enables creation of layered CUDA arrays. When this flag is set, depth specifies the
         /// number of layers, not the depth of a 3D array.
         const LAYERED = cuda_sys::cuda::CUDA_ARRAY3D_LAYERED;
 
@@ -82,46 +89,6 @@ impl ArrayObjectFlags {
     pub fn new() -> Self {
         Self::default()
     }
-
-    /// Checks if LAYERED flag is set
-    pub fn layered(self) -> bool {
-        self.contains(ArrayObjectFlags::LAYERED)
-    }
-
-    /// Returns a copy of `self` with the LAYERED flag set
-    pub fn mark_layered(self) -> ArrayObjectFlags {
-        self | ArrayObjectFlags::LAYERED
-    }
-
-    /// Checks if SURFACE_LDST flag is set
-    pub fn surface_ldst(self) -> bool {
-        self.contains(ArrayObjectFlags::SURFACE_LDST)
-    }
-
-    /// Returns a copy of `self` with the SURFACE_LDST flag set
-    pub fn mark_surface_ldst(self) -> ArrayObjectFlags {
-        self | ArrayObjectFlags::SURFACE_LDST
-    }
-
-    /// Checks if CUBEMAP flag is set
-    pub fn cubemap(self) -> bool {
-        self.contains(ArrayObjectFlags::CUBEMAP)
-    }
-
-    /// Returns a copy of `self` with the CUBEMAP flag set
-    pub fn mark_cubemap(self) -> ArrayObjectFlags {
-        self | ArrayObjectFlags::CUBEMAP
-    }
-
-    /// Checks if TEXTURE_GATHER flag is set
-    pub fn texture_gather(self) -> bool {
-        self.contains(ArrayObjectFlags::TEXTURE_GATHER)
-    }
-
-    /// Returns a copy of `self` with the TEXTURE_GATHER flag set
-    pub fn mark_texture_gather(self) -> ArrayObjectFlags {
-        self | ArrayObjectFlags::TEXTURE_GATHER
-    }
 }
 
 /// Describes a CUDA Array
@@ -134,6 +101,25 @@ impl ArrayDescriptor {
     /// Constructs an ArrayDescriptor from a CUDA Driver API Array Descriptor.
     pub fn from_raw(desc: cuda_sys::cuda::CUDA_ARRAY3D_DESCRIPTOR) -> Self {
         Self { desc }
+    }
+
+    /// Constructs an ArrayDescriptor from dimensions, format, num_channels, and flags.
+    pub fn new(
+        dims: [usize; 3],
+        format: ArrayFormat,
+        num_channels: c_uint,
+        flags: ArrayObjectFlags,
+    ) -> Self {
+        Self {
+            desc: cuda_sys::cuda::CUDA_ARRAY3D_DESCRIPTOR {
+                Width: dims[0],
+                Height: dims[1],
+                Depth: dims[2],
+                Format: format.to_raw(),
+                NumChannels: num_channels,
+                Flags: flags.bits(),
+            },
+        }
     }
 
     /// Creates a new ArrayDescriptor from a set of dimensions and format.
@@ -162,12 +148,6 @@ impl ArrayDescriptor {
         self.desc.Depth = dims[2];
     }
 
-    /// Sets the dimensions of the ArrayDescriptor. Composes with other with_ routines.
-    pub fn with_dims(mut self, dims: [usize; 3]) -> Self {
-        self.set_dims(dims);
-        self
-    }
-
     /// Returns the width of the ArrayDescripor
     pub fn width(&self) -> usize {
         self.desc.Width
@@ -176,12 +156,6 @@ impl ArrayDescriptor {
     /// Sets the width of the ArrayDescriptor
     pub fn set_width(&mut self, width: usize) {
         self.desc.Width = width;
-    }
-
-    /// Sets the width of the ArrayDescriptor. Composes with other with_ routines.
-    pub fn mark_width(mut self, width: usize) -> Self {
-        self.set_width(width);
-        self
     }
 
     /// Returns the height of the ArrayDescripor
@@ -194,12 +168,6 @@ impl ArrayDescriptor {
         self.desc.Height = height;
     }
 
-    /// Sets the height of the ArrayDescriptor. Composes with other with_ routines.
-    pub fn with_height(mut self, height: usize) -> Self {
-        self.set_height(height);
-        self
-    }
-
     /// Returns the depth of the ArrayDescripor
     pub fn depth(&self) -> usize {
         self.desc.Depth
@@ -208,12 +176,6 @@ impl ArrayDescriptor {
     /// Sets the depth of the ArrayDescriptor
     pub fn set_depth(&mut self, depth: usize) {
         self.desc.Depth = depth;
-    }
-
-    /// Sets the depth of the ArrayDescriptor. Composes with other with_ routines.
-    pub fn with_depth(mut self, depth: usize) -> Self {
-        self.set_depth(depth);
-        self
     }
 
     /// Returns the format of the ArrayDescripor
@@ -226,12 +188,6 @@ impl ArrayDescriptor {
         self.desc.Format = format.to_raw();
     }
 
-    /// Sets the format of the ArrayDescriptor. Composes with other with_ routines.
-    pub fn with_format(mut self, format: ArrayFormat) -> Self {
-        self.set_format(format);
-        self
-    }
-
     /// Returns the number of channels in the ArrayDescriptor
     pub fn num_channels(&self) -> c_uint {
         self.desc.NumChannels
@@ -240,12 +196,6 @@ impl ArrayDescriptor {
     /// Sets the number of channels in the ArrayDescriptor
     pub fn set_num_channels(&mut self, num_channels: c_uint) {
         self.desc.NumChannels = num_channels;
-    }
-
-    /// Sets the number of channels in the ArrayDescriptor. Composes with other with_ routinese.
-    pub fn with_num_channels(mut self, num_channels: c_uint) -> Self {
-        self.set_num_channels(num_channels);
-        self
     }
 
     /// Returns the flags of the ArrayDescriptor
@@ -257,12 +207,6 @@ impl ArrayDescriptor {
     pub fn set_flags(&mut self, flags: ArrayObjectFlags) {
         self.desc.Flags = flags.bits();
     }
-
-    /// Sets the flags of the ArrayDescriptor. Composes with other with_ routines.
-    pub fn with_flags(mut self, flags: ArrayObjectFlags) -> Self {
-        self.set_flags(flags);
-        self
-    }
 }
 
 /// A CUDA Array. Can be bound to a texture or surface.
@@ -271,60 +215,409 @@ pub struct ArrayObject {
 }
 
 impl ArrayObject {
-    /// Constructs a generic ArrayObject
-    pub fn from_descriptor(descriptor: ArrayDescriptor) -> CudaResult<Self> {
-        // We validate the descriptor up front. This provides a good error message to the user.
-        assert_ne!(
-            0,
-            descriptor.width(),
-            "Cannot allocate an array with 0 Width"
-        );
-
-        if !descriptor.flags().layered() && descriptor.depth() > 0 {
+    /// Constructs a generic ArrayObject from an `ArrayDescriptor`.
+    pub fn from_descriptor(descriptor: &ArrayDescriptor) -> CudaResult<Self> {
+        // We validate the descriptor up front in debug mode. This provides a good error message to
+        // the user when they get something wrong, but doesn't re-validate in release mode.
+        if cfg!(debug_assertions) {
             assert_ne!(
                 0,
-                descriptor.height(),
-                "If Depth is non-zero and the descriptor is not LAYERED, then Height must also be \
-                 non-zero."
-            );
-        }
-
-        if descriptor.flags().cubemap() {
-            assert_eq!(
-                descriptor.height(),
                 descriptor.width(),
-                "Height and Width must be equal for CUBEMAP arrays."
+                "Cannot allocate an array with 0 Width"
             );
 
-            if descriptor.flags().layered() {
-                assert_eq!(
+            if !descriptor.flags().contains(ArrayObjectFlags::LAYERED) && descriptor.depth() > 0 {
+                assert_ne!(
                     0,
-                    descriptor.depth() % 6,
-                    "Depth must be a multiple of 6 when the array descriptor is for a LAYERED \
-                     CUBEMAP."
-                );
-            } else {
-                assert_eq!(
-                    6,
-                    descriptor.depth(),
-                    "Depth must be equal to 6 when the array descriptor is for a CUBEMAP."
+                    descriptor.height(),
+                    "If Depth is non-zero and the descriptor is not LAYERED, then Height must also \
+                    be non-zero."
                 );
             }
-        }
 
-        if descriptor.num_channels() != 1
-            && descriptor.num_channels() != 2
-            && descriptor.num_channels() != 4
-        {
-            panic!(
+            if descriptor.flags().contains(ArrayObjectFlags::CUBEMAP) {
+                assert_eq!(
+                    descriptor.height(),
+                    descriptor.width(),
+                    "Height and Width must be equal for CUBEMAP arrays."
+                );
+
+                if descriptor.flags().contains(ArrayObjectFlags::LAYERED) {
+                    assert_eq!(
+                        0,
+                        descriptor.depth() % 6,
+                        "Depth must be a multiple of 6 when the array descriptor is for a LAYERED \
+                         CUBEMAP."
+                    );
+                } else {
+                    assert_eq!(
+                        6,
+                        descriptor.depth(),
+                        "Depth must be equal to 6 when the array descriptor is for a CUBEMAP."
+                    );
+                }
+            }
+
+            assert!(
+                descriptor.num_channels() == 1
+                    || descriptor.num_channels() == 2
+                    || descriptor.num_channels() == 4,
                 "NumChannels was set to {}. It must be 1, 2, or 4.",
                 descriptor.num_channels()
             );
+
+            // Exhaustively check bounds of arrays
+            let device = CurrentContext::get_device()?;
+
+            let attr = |attr| Ok(1..(device.get_attribute(attr)? as usize) + 1);
+
+            let (description, bounds) = if descriptor.flags().contains(ArrayObjectFlags::CUBEMAP) {
+                if descriptor.flags().contains(ArrayObjectFlags::LAYERED) {
+                    (
+                        "Layered Cubemap",
+                        vec![[
+                            attr(DeviceAttribute::MaximumTextureCubemapLayeredWidth)?,
+                            attr(DeviceAttribute::MaximumTextureCubemapLayeredWidth)?,
+                            attr(DeviceAttribute::MaximumTextureCubemapLayeredLayers)?,
+                        ]],
+                    )
+                } else {
+                    (
+                        "Cubemap",
+                        vec![[
+                            attr(DeviceAttribute::MaximumTextureCubemapWidth)?,
+                            attr(DeviceAttribute::MaximumTextureCubemapWidth)?,
+                            6..7,
+                        ]],
+                    )
+                }
+            } else if descriptor.flags().contains(ArrayObjectFlags::LAYERED) {
+                if descriptor.height() > 0 {
+                    (
+                        "2D Layered",
+                        vec![[
+                            attr(DeviceAttribute::MaximumTexture2DLayeredWidth)?,
+                            attr(DeviceAttribute::MaximumTexture2DLayeredHeight)?,
+                            attr(DeviceAttribute::MaximumTexture2DLayeredLayers)?,
+                        ]],
+                    )
+                } else {
+                    (
+                        "1D Layered",
+                        vec![[
+                            attr(DeviceAttribute::MaximumTexture1DLayeredWidth)?,
+                            0..1,
+                            attr(DeviceAttribute::MaximumTexture1DLayeredLayers)?,
+                        ]],
+                    )
+                }
+            } else if descriptor.depth() > 0 {
+                (
+                    "3D",
+                    vec![
+                        [
+                            attr(DeviceAttribute::MaximumTexture3DWidth)?,
+                            attr(DeviceAttribute::MaximumTexture3DHeight)?,
+                            attr(DeviceAttribute::MaximumTexture3DDepth)?,
+                        ],
+                        [
+                            attr(DeviceAttribute::MaximumTexture3DWidthAlternate)?,
+                            attr(DeviceAttribute::MaximumTexture3DHeightAlternate)?,
+                            attr(DeviceAttribute::MaximumTexture3DDepthAlternate)?,
+                        ],
+                    ],
+                )
+            } else if descriptor.height() > 0 {
+                if descriptor
+                    .flags()
+                    .contains(ArrayObjectFlags::TEXTURE_GATHER)
+                {
+                    (
+                        "2D Texture Gather",
+                        vec![[
+                            attr(DeviceAttribute::MaximumTexture2DGatherWidth)?,
+                            attr(DeviceAttribute::MaximumTexture2DGatherHeight)?,
+                            0..1,
+                        ]],
+                    )
+                } else {
+                    (
+                        "2D",
+                        vec![[
+                            attr(DeviceAttribute::MaximumTexture2DWidth)?,
+                            attr(DeviceAttribute::MaximumTexture2DHeight)?,
+                            0..1,
+                        ]],
+                    )
+                }
+            } else {
+                assert!(descriptor.width() > 0);
+                (
+                    "1D",
+                    vec![[attr(DeviceAttribute::MaximumTexture1DWidth)?, 0..1, 0..1]],
+                )
+            };
+
+            if !bounds.iter().any(|x| {
+                (descriptor.width() >= x[0].start && descriptor.width() < x[0].end)
+                    && (descriptor.height() >= x[1].start && descriptor.height() < x[1].end)
+                    && (descriptor.depth() >= x[2].start && descriptor.depth() < x[2].end)
+            }) {
+                panic!(
+                    "The dimensions of the {} ArrayObject did not fall within the valid bounds for \
+                     the array. descriptor = {:?}, dims = {:?}, valid bounds = {:?}",
+                     description,
+                     descriptor,
+                     [descriptor.width(), descriptor.height(), descriptor.depth()],
+                     bounds
+                );
+            }
         }
 
         let mut handle = unsafe { std::mem::uninitialized() };
         unsafe { cuda_sys::cuda::cuArray3DCreate_v2(&mut handle, &descriptor.desc) }.to_result()?;
         Ok(Self { handle })
+    }
+
+    /// Allocates a new CUDA Array that is up to 3-dimensions.
+    ///
+    /// `dims` contains the extents of the array. `dims[0]` must be non-zero. `dims[1]` must be
+    /// non-zero if `dims[2]` is non-zero. The rank of the array is equal to the number of non-zero
+    /// `dims`.
+    ///
+    /// `format` determines the data-type of the array.
+    ///
+    /// `num_channels` determines the number of channels per array element (1, 2, or 4).
+    ///
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let _ctx = quick_init()?;
+    /// use rustacuda::memory::array::{ArrayObject, ArrayFormat};
+    ///
+    /// let one_dim_array = ArrayObject::new([10, 0, 0], ArrayFormat::Float, 1)?;
+    /// let two_dim_array = ArrayObject::new([10, 12, 0], ArrayFormat::Float, 1)?;
+    /// let three_dim_array = ArrayObject::new([10, 12, 14], ArrayFormat::Float, 1)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new(dims: [usize; 3], format: ArrayFormat, num_channels: c_uint) -> CudaResult<Self> {
+        Self::from_descriptor(&ArrayDescriptor::new(
+            dims,
+            format,
+            num_channels,
+            Default::default(),
+        ))
+    }
+
+    /// Allocates a new 1D CUDA Array.
+    ///
+    /// `width` must be non-zero.
+    ///
+    /// `format` determines the data-type of the array.
+    ///
+    /// `num_channels` determines the number of channels per array element (1, 2, or 4).
+    ///
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let _ctx = quick_init()?;
+    /// use rustacuda::memory::array::{ArrayObject, ArrayFormat};
+    ///
+    /// // Allocates a 1D array of 10 single-precision, single-channel floating point values.
+    /// let one_dim_array = ArrayObject::new_1d(10, ArrayFormat::Float, 1)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_1d(width: usize, format: ArrayFormat, num_channels: c_uint) -> CudaResult<Self> {
+        Self::from_descriptor(&ArrayDescriptor::new(
+            [width, 0, 0],
+            format,
+            num_channels,
+            Default::default(),
+        ))
+    }
+
+    /// Allocates a new CUDA Array that is up to 2-dimensions.
+    ///
+    /// `dims` contains the extents of the array. `dims[0]` must be non-zero. The rank of the array
+    /// is equal to the number of non-zero `dims`.
+    ///
+    /// `format` determines the data-type of the array.
+    ///
+    /// `num_channels` determines the number of channels per array element (1, 2, or 4).
+    ///
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let _ctx = quick_init()?;
+    /// use rustacuda::memory::array::{ArrayObject, ArrayFormat};
+    ///
+    /// // Allocates an 8x24 array of single-precision, single-channel floating point values.
+    /// let one_dim_array = ArrayObject::new_2d([8, 24], ArrayFormat::Float, 1)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_2d(dims: [usize; 2], format: ArrayFormat, num_channels: c_uint) -> CudaResult<Self> {
+        Self::from_descriptor(&ArrayDescriptor::new(
+            [dims[0], dims[1], 0],
+            format,
+            num_channels,
+            Default::default(),
+        ))
+    }
+
+    /// Creates a new Layered 1D or 2D CUDA Array.
+    ///
+    /// `dims` contains the extents of the array. `dims[0]` must be non-zero. The rank of the array
+    /// is equivalent to the number of non-zero dimensions.
+    ///
+    /// `num_layers` determines the number of layers in the array.
+    ///
+    /// `format` determines the data-type of the array.
+    ///
+    /// `num_channels` determines the number of channels per array element (1, 2, or 4).
+    ///
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let _ctx = quick_init()?;
+    /// use rustacuda::memory::array::{ArrayObject, ArrayFormat};
+    ///
+    /// // Allocates a 7x8 array with 10 layers of single-precision, single-channel floating
+    /// // point values.
+    /// let layered_array = ArrayObject::new_layered([7, 8], 10, ArrayFormat::Float, 1)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_layered(
+        dims: [usize; 2],
+        num_layers: usize,
+        format: ArrayFormat,
+        num_channels: c_uint,
+    ) -> CudaResult<Self> {
+        Self::from_descriptor(&ArrayDescriptor::new(
+            [dims[0], dims[1], num_layers],
+            format,
+            num_channels,
+            ArrayObjectFlags::LAYERED,
+        ))
+    }
+
+    /// Creates a new Layered 1D CUDA Array.
+    ///
+    /// `width` must be non-zero.
+    ///
+    /// `num_layers` determines the number of layers in the array.
+    ///
+    /// `format` determines the data-type of the array.
+    ///
+    /// `num_channels` determines the number of channels per array element (1, 2, or 4).
+    ///
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let _ctx = quick_init()?;
+    /// use rustacuda::memory::array::{ArrayObject, ArrayFormat};
+    ///
+    /// // Allocates a 5-element array with 10 layers of single-precision, single-channel floating
+    /// // point values.
+    /// let layered_array = ArrayObject::new_layered_1d(5, 10, ArrayFormat::Float, 1)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_layered_1d(
+        width: usize,
+        num_layers: usize,
+        format: ArrayFormat,
+        num_channels: c_uint,
+    ) -> CudaResult<Self> {
+        Self::from_descriptor(&ArrayDescriptor::new(
+            [width, 0, num_layers],
+            format,
+            num_channels,
+            ArrayObjectFlags::LAYERED,
+        ))
+    }
+
+    /// Creates a new Cubemap CUDA Array. The array is represented as 6 side x side 2D arrays.
+    ///
+    /// `side` is the length of an edge of the cube.
+    ///
+    /// `format` determines the data-type of the array.
+    ///
+    /// `num_channels` determines the number of channels per array element (1, 2, or 4).
+    ///
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let _ctx = quick_init()?;
+    /// use rustacuda::memory::array::{ArrayObject, ArrayFormat};
+    ///
+    /// // Allocates an 8x8 Cubemap array of single-precision, single-channel floating point
+    /// // numbers.
+    /// let layered_array = ArrayObject::new_cubemap(8, ArrayFormat::Float, 1)?;
+    ///
+    /// // All non-layered cubemap arrays have a depth of 6.
+    /// assert_eq!(6, layered_array.descriptor()?.depth());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_cubemap(side: usize, format: ArrayFormat, num_channels: c_uint) -> CudaResult<Self> {
+        Self::from_descriptor(&ArrayDescriptor::new(
+            [side, side, 6],
+            format,
+            num_channels,
+            ArrayObjectFlags::CUBEMAP,
+        ))
+    }
+
+    /// Creates a new Layered Cubemap CUDA Array. The array is represented as multiple 6 side x side
+    /// 2D arrays.
+    ///
+    /// `side` is the length of an edge of the cube.
+    ///
+    /// `num_layers` is the number of cubemaps in the array. The actual "depth" of the array is
+    /// `num_layers * 6`.
+    ///
+    /// `format` determines the data-type of the array.
+    ///
+    /// `num_channels` determines the number of channels per array element (1, 2, or 4).
+    ///
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # let _ctx = quick_init()?;
+    /// use rustacuda::memory::array::{ArrayObject, ArrayFormat};
+    ///
+    /// // Allocates an 8x8 Layered Cubemap array of single-precision, single-channel floating point
+    /// // values with 5 layers.
+    /// let layered_array = ArrayObject::new_layered_cubemap(8, 5, ArrayFormat::Float, 1)?;
+    ///
+    /// // The depth of a layered cubemap array is equal to the number of layers * 6.
+    /// assert_eq!(30, layered_array.descriptor()?.depth());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new_layered_cubemap(
+        side: usize,
+        num_layers: usize,
+        format: ArrayFormat,
+        num_channels: c_uint,
+    ) -> CudaResult<Self> {
+        Self::from_descriptor(&ArrayDescriptor::new(
+            [side, side, num_layers * 6],
+            format,
+            num_channels,
+            ArrayObjectFlags::CUBEMAP | ArrayObjectFlags::LAYERED,
+        ))
     }
 
     /// Gets the descriptor associated with this array.
@@ -368,10 +661,7 @@ mod test {
     fn descriptor_round_trip() {
         let _context = crate::quick_init().unwrap();
 
-        let obj = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([1, 2, 3], ArrayFormat::Float).with_num_channels(2),
-        )
-        .unwrap();
+        let obj = ArrayObject::new([1, 2, 3], ArrayFormat::Float, 2).unwrap();
 
         let descriptor = obj.descriptor().unwrap();
         assert_eq!([1, 2, 3], descriptor.dims());
@@ -384,11 +674,7 @@ mod test {
     fn allow_1d_arrays() {
         let _context = crate::quick_init().unwrap();
 
-        let obj = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
-            [10, 0, 0],
-            ArrayFormat::Float,
-        ))
-        .unwrap();
+        let obj = ArrayObject::new([10, 0, 0], ArrayFormat::Float, 1).unwrap();
 
         let descriptor = obj.descriptor().unwrap();
         assert_eq!([10, 0, 0], descriptor.dims());
@@ -398,11 +684,7 @@ mod test {
     fn allow_2d_arrays() {
         let _context = crate::quick_init().unwrap();
 
-        let obj = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
-            [10, 20, 0],
-            ArrayFormat::Float,
-        ))
-        .unwrap();
+        let obj = ArrayObject::new([10, 20, 0], ArrayFormat::Float, 1).unwrap();
 
         let descriptor = obj.descriptor().unwrap();
         assert_eq!([10, 20, 0], descriptor.dims());
@@ -412,11 +694,7 @@ mod test {
     fn allow_1d_layered_arrays() {
         let _context = crate::quick_init().unwrap();
 
-        let obj = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([10, 0, 20], ArrayFormat::Float)
-                .with_flags(ArrayObjectFlags::LAYERED),
-        )
-        .unwrap();
+        let obj = ArrayObject::new_layered([10, 0], 20, ArrayFormat::Float, 1).unwrap();
 
         let descriptor = obj.descriptor().unwrap();
         assert_eq!([10, 0, 20], descriptor.dims());
@@ -427,11 +705,7 @@ mod test {
     fn allow_cubemaps() {
         let _context = crate::quick_init().unwrap();
 
-        let obj = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([4, 4, 6], ArrayFormat::Float)
-                .with_flags(ArrayObjectFlags::CUBEMAP),
-        )
-        .unwrap();
+        let obj = ArrayObject::new_cubemap(4, ArrayFormat::Float, 1).unwrap();
 
         let descriptor = obj.descriptor().unwrap();
         assert_eq!([4, 4, 6], descriptor.dims());
@@ -442,11 +716,7 @@ mod test {
     fn allow_layered_cubemaps() {
         let _context = crate::quick_init().unwrap();
 
-        let obj = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([4, 4, 24], ArrayFormat::Float)
-                .with_flags(ArrayObjectFlags::new().mark_layered().mark_cubemap()),
-        )
-        .unwrap();
+        let obj = ArrayObject::new_layered_cubemap(4, 4, ArrayFormat::Float, 1).unwrap();
 
         let descriptor = obj.descriptor().unwrap();
         assert_eq!([4, 4, 24], descriptor.dims());
@@ -457,89 +727,67 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "\
-assertion failed: `(left != right)`
-  left: `0`,
- right: `0`: Cannot allocate an array with 0 Width")]
+    #[should_panic]
+    fn fail_on_zero_width_1d_array() {
+        let _context = crate::quick_init().unwrap();
+
+        let _ = ArrayObject::new_1d(0, ArrayFormat::Float, 1).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
     fn fail_on_zero_size_widths() {
         let _context = crate::quick_init().unwrap();
 
-        let _ = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
-            [0, 10, 20],
-            ArrayFormat::Float,
-        ))
-        .unwrap();
+        let _ = ArrayObject::new([0, 10, 20], ArrayFormat::Float, 1).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "\
-assertion failed: `(left == right)`
-  left: `3`,
- right: `2`: Height and Width must be equal for CUBEMAP arrays.")]
+    #[should_panic]
     fn fail_cubemaps_with_unmatching_width_height() {
         let _context = crate::quick_init().unwrap();
 
-        let _ = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([2, 3, 6], ArrayFormat::Float)
-                .with_flags(ArrayObjectFlags::CUBEMAP),
-        )
-        .unwrap();
+        let mut descriptor = ArrayDescriptor::from_dims_format([2, 3, 6], ArrayFormat::Float);
+        descriptor.set_flags(ArrayObjectFlags::CUBEMAP);
+
+        let _ = ArrayObject::from_descriptor(&descriptor).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "\
-assertion failed: `(left == right)`
-  left: `6`,
- right: `5`: Depth must be equal to 6 when the array descriptor is for a CUBEMAP.")]
+    #[should_panic]
     fn fail_cubemaps_with_non_six_depth() {
         let _context = crate::quick_init().unwrap();
 
-        let _ = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([4, 4, 5], ArrayFormat::Float)
-                .with_flags(ArrayObjectFlags::CUBEMAP),
-        )
-        .unwrap();
+        let mut descriptor = ArrayDescriptor::from_dims_format([4, 4, 5], ArrayFormat::Float);
+        descriptor.set_flags(ArrayObjectFlags::CUBEMAP);
+
+        let _ = ArrayObject::from_descriptor(&descriptor).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "\
-assertion failed: `(left == right)`
-  left: `0`,
- right: `4`: Depth must be a multiple of 6 when the array descriptor is for a LAYERED CUBEMAP.")]
+    #[should_panic]
     fn fail_cubemaps_with_non_six_multiple_depth() {
         let _context = crate::quick_init().unwrap();
 
-        let _ = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([4, 4, 10], ArrayFormat::Float)
-                .with_flags(ArrayObjectFlags::LAYERED | ArrayObjectFlags::CUBEMAP),
-        )
-        .unwrap();
+        let mut descriptor = ArrayDescriptor::from_dims_format([4, 4, 10], ArrayFormat::Float);
+        descriptor.set_flags(ArrayObjectFlags::LAYERED | ArrayObjectFlags::CUBEMAP);
+
+        let _ = ArrayObject::from_descriptor(&descriptor).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "\
-assertion failed: `(left != right)`
-  left: `0`,
- right: `0`: If Depth is non-zero and the descriptor is not LAYERED, then Height must also be \
-             non-zero.")]
+    #[should_panic]
     fn fail_with_depth_without_height() {
         let _context = crate::quick_init().unwrap();
 
-        let _ = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
-            [10, 0, 20],
-            ArrayFormat::Float,
-        ))
-        .unwrap();
+        let _ = ArrayObject::new([10, 0, 20], ArrayFormat::Float, 1).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "NumChannels was set to 3. It must be 1, 2, or 4.")]
+    #[should_panic]
     fn fails_on_invalid_num_channels() {
         let _context = crate::quick_init().unwrap();
 
-        let _ = ArrayObject::from_descriptor(
-            ArrayDescriptor::from_dims_format([1, 2, 3], ArrayFormat::Float).with_num_channels(3),
-        )
-        .unwrap();
+        let _ = ArrayObject::new([1, 2, 3], ArrayFormat::Float, 3).unwrap();
     }
 }

--- a/src/memory/array.rs
+++ b/src/memory/array.rs
@@ -1,0 +1,545 @@
+use std::os::raw::c_uint;
+
+use cuda_sys::cuda::{CUarray, CUarray_format, CUarray_format_enum};
+
+use crate::error::*;
+
+/// Describes the format used for a CUDA Array.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArrayFormat {
+    /// Unsigned 8-bit integer
+    UnsignedInt8,
+    /// Unsigned 16-bit integer
+    UnsignedInt16,
+    /// Unsigned 32-bit integer
+    UnsignedInt32,
+    /// Signed 8-bit integer
+    SignedInt8,
+    /// Signed 16-bit integer
+    SignedInt16,
+    /// Signed 32-bit integer
+    SignedInt32,
+    /// Half-precision floating point number
+    Half,
+    /// Single-precision floating point number
+    Float,
+}
+
+impl ArrayFormat {
+    /// Creates ArrayFormat from the CUDA Driver API enum
+    pub fn from_raw(raw: CUarray_format) -> Self {
+        match raw {
+            CUarray_format_enum::CU_AD_FORMAT_UNSIGNED_INT8 => ArrayFormat::UnsignedInt8,
+            CUarray_format_enum::CU_AD_FORMAT_UNSIGNED_INT16 => ArrayFormat::UnsignedInt16,
+            CUarray_format_enum::CU_AD_FORMAT_UNSIGNED_INT32 => ArrayFormat::UnsignedInt32,
+            CUarray_format_enum::CU_AD_FORMAT_SIGNED_INT8 => ArrayFormat::SignedInt8,
+            CUarray_format_enum::CU_AD_FORMAT_SIGNED_INT16 => ArrayFormat::SignedInt16,
+            CUarray_format_enum::CU_AD_FORMAT_SIGNED_INT32 => ArrayFormat::SignedInt32,
+            CUarray_format_enum::CU_AD_FORMAT_HALF => ArrayFormat::Half,
+            CUarray_format_enum::CU_AD_FORMAT_FLOAT => ArrayFormat::Float,
+        }
+    }
+
+    /// Converts ArrayFormat to the CUDA Driver API enum
+    pub fn to_raw(self) -> CUarray_format {
+        match self {
+            ArrayFormat::UnsignedInt8 => CUarray_format_enum::CU_AD_FORMAT_UNSIGNED_INT8,
+            ArrayFormat::UnsignedInt16 => CUarray_format_enum::CU_AD_FORMAT_UNSIGNED_INT16,
+            ArrayFormat::UnsignedInt32 => CUarray_format_enum::CU_AD_FORMAT_UNSIGNED_INT32,
+            ArrayFormat::SignedInt8 => CUarray_format_enum::CU_AD_FORMAT_SIGNED_INT8,
+            ArrayFormat::SignedInt16 => CUarray_format_enum::CU_AD_FORMAT_SIGNED_INT16,
+            ArrayFormat::SignedInt32 => CUarray_format_enum::CU_AD_FORMAT_SIGNED_INT32,
+            ArrayFormat::Half => CUarray_format_enum::CU_AD_FORMAT_HALF,
+            ArrayFormat::Float => CUarray_format_enum::CU_AD_FORMAT_FLOAT,
+        }
+    }
+}
+
+bitflags! {
+    /// Flags which modify the behavior of CUDA array creation.
+    #[derive(Default)]
+    pub struct ArrayObjectFlags: c_uint {
+        /// Enables creation of layered CUDA array.s When this flag is set, depth specifies the
+        /// number of layers, not the depth of a 3D array.
+        const LAYERED = cuda_sys::cuda::CUDA_ARRAY3D_LAYERED;
+
+        /// Enables surface references to be bound to the CUDA array.
+        const SURFACE_LDST = cuda_sys::cuda::CUDA_ARRAY3D_SURFACE_LDST;
+
+        /// Enables creation of cubemaps. If this flag is set, Width must be equal to Height, and
+        /// Depth must be six. If the `LAYERED` flag is also set, then Depth must be a multiple of
+        /// six.
+        const CUBEMAP = cuda_sys::cuda::CUDA_ARRAY3D_CUBEMAP;
+
+        /// Indicates that the CUDA array will be used for texture gather. Texture gather can only
+        /// be performed on 2D CUDA arrays.
+        const TEXTURE_GATHER = cuda_sys::cuda::CUDA_ARRAY3D_TEXTURE_GATHER;
+    }
+}
+
+impl ArrayObjectFlags {
+    /// Creates a default flags object with no flags set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Checks if LAYERED flag is set
+    pub fn layered(self) -> bool {
+        self.contains(ArrayObjectFlags::LAYERED)
+    }
+
+    /// Returns a copy of `self` with the LAYERED flag set
+    pub fn mark_layered(self) -> ArrayObjectFlags {
+        self | ArrayObjectFlags::LAYERED
+    }
+
+    /// Checks if SURFACE_LDST flag is set
+    pub fn surface_ldst(self) -> bool {
+        self.contains(ArrayObjectFlags::SURFACE_LDST)
+    }
+
+    /// Returns a copy of `self` with the SURFACE_LDST flag set
+    pub fn mark_surface_ldst(self) -> ArrayObjectFlags {
+        self | ArrayObjectFlags::SURFACE_LDST
+    }
+
+    /// Checks if CUBEMAP flag is set
+    pub fn cubemap(self) -> bool {
+        self.contains(ArrayObjectFlags::CUBEMAP)
+    }
+
+    /// Returns a copy of `self` with the CUBEMAP flag set
+    pub fn mark_cubemap(self) -> ArrayObjectFlags {
+        self | ArrayObjectFlags::CUBEMAP
+    }
+
+    /// Checks if TEXTURE_GATHER flag is set
+    pub fn texture_gather(self) -> bool {
+        self.contains(ArrayObjectFlags::TEXTURE_GATHER)
+    }
+
+    /// Returns a copy of `self` with the TEXTURE_GATHER flag set
+    pub fn mark_texture_gather(self) -> ArrayObjectFlags {
+        self | ArrayObjectFlags::TEXTURE_GATHER
+    }
+}
+
+/// Describes a CUDA Array
+#[derive(Clone, Copy, Debug)]
+pub struct ArrayDescriptor {
+    desc: cuda_sys::cuda::CUDA_ARRAY3D_DESCRIPTOR,
+}
+
+impl ArrayDescriptor {
+    /// Constructs an ArrayDescriptor from a CUDA Driver API Array Descriptor.
+    pub fn from_raw(desc: cuda_sys::cuda::CUDA_ARRAY3D_DESCRIPTOR) -> Self {
+        Self { desc }
+    }
+
+    /// Creates a new ArrayDescriptor from a set of dimensions and format.
+    pub fn from_dims_format(dims: [usize; 3], format: ArrayFormat) -> Self {
+        Self {
+            desc: cuda_sys::cuda::CUDA_ARRAY3D_DESCRIPTOR {
+                Width: dims[0],
+                Height: dims[1],
+                Depth: dims[2],
+                Format: format.to_raw(),
+                NumChannels: 1,
+                Flags: ArrayObjectFlags::default().bits(),
+            },
+        }
+    }
+
+    /// Returns the dimensions of the ArrayDescriptor
+    pub fn dims(&self) -> [usize; 3] {
+        [self.desc.Width, self.desc.Height, self.desc.Depth]
+    }
+
+    /// Sets the dimensions of the ArrayDescriptor
+    pub fn set_dims(&mut self, dims: [usize; 3]) {
+        self.desc.Width = dims[0];
+        self.desc.Height = dims[1];
+        self.desc.Depth = dims[2];
+    }
+
+    /// Sets the dimensions of the ArrayDescriptor. Composes with other with_ routines.
+    pub fn with_dims(mut self, dims: [usize; 3]) -> Self {
+        self.set_dims(dims);
+        self
+    }
+
+    /// Returns the width of the ArrayDescripor
+    pub fn width(&self) -> usize {
+        self.desc.Width
+    }
+
+    /// Sets the width of the ArrayDescriptor
+    pub fn set_width(&mut self, width: usize) {
+        self.desc.Width = width;
+    }
+
+    /// Sets the width of the ArrayDescriptor. Composes with other with_ routines.
+    pub fn mark_width(mut self, width: usize) -> Self {
+        self.set_width(width);
+        self
+    }
+
+    /// Returns the height of the ArrayDescripor
+    pub fn height(&self) -> usize {
+        self.desc.Height
+    }
+
+    /// Sets the height of the ArrayDescriptor
+    pub fn set_height(&mut self, height: usize) {
+        self.desc.Height = height;
+    }
+
+    /// Sets the height of the ArrayDescriptor. Composes with other with_ routines.
+    pub fn with_height(mut self, height: usize) -> Self {
+        self.set_height(height);
+        self
+    }
+
+    /// Returns the depth of the ArrayDescripor
+    pub fn depth(&self) -> usize {
+        self.desc.Depth
+    }
+
+    /// Sets the depth of the ArrayDescriptor
+    pub fn set_depth(&mut self, depth: usize) {
+        self.desc.Depth = depth;
+    }
+
+    /// Sets the depth of the ArrayDescriptor. Composes with other with_ routines.
+    pub fn with_depth(mut self, depth: usize) -> Self {
+        self.set_depth(depth);
+        self
+    }
+
+    /// Returns the format of the ArrayDescripor
+    pub fn format(&self) -> ArrayFormat {
+        ArrayFormat::from_raw(self.desc.Format)
+    }
+
+    /// Sets the format of the ArrayDescriptor
+    pub fn set_format(&mut self, format: ArrayFormat) {
+        self.desc.Format = format.to_raw();
+    }
+
+    /// Sets the format of the ArrayDescriptor. Composes with other with_ routines.
+    pub fn with_format(mut self, format: ArrayFormat) -> Self {
+        self.set_format(format);
+        self
+    }
+
+    /// Returns the number of channels in the ArrayDescriptor
+    pub fn num_channels(&self) -> c_uint {
+        self.desc.NumChannels
+    }
+
+    /// Sets the number of channels in the ArrayDescriptor
+    pub fn set_num_channels(&mut self, num_channels: c_uint) {
+        self.desc.NumChannels = num_channels;
+    }
+
+    /// Sets the number of channels in the ArrayDescriptor. Composes with other with_ routinese.
+    pub fn with_num_channels(mut self, num_channels: c_uint) -> Self {
+        self.set_num_channels(num_channels);
+        self
+    }
+
+    /// Returns the flags of the ArrayDescriptor
+    pub fn flags(&self) -> ArrayObjectFlags {
+        ArrayObjectFlags::from_bits_truncate(self.desc.Flags)
+    }
+
+    /// Sets the flags of the ArrayDescriptor.
+    pub fn set_flags(&mut self, flags: ArrayObjectFlags) {
+        self.desc.Flags = flags.bits();
+    }
+
+    /// Sets the flags of the ArrayDescriptor. Composes with other with_ routines.
+    pub fn with_flags(mut self, flags: ArrayObjectFlags) -> Self {
+        self.set_flags(flags);
+        self
+    }
+}
+
+/// A CUDA Array. Can be bound to a texture or surface.
+pub struct ArrayObject {
+    handle: CUarray,
+}
+
+impl ArrayObject {
+    /// Constructs a generic ArrayObject
+    pub fn from_descriptor(descriptor: ArrayDescriptor) -> CudaResult<Self> {
+        // We validate the descriptor up front. This provides a good error message to the user.
+        assert_ne!(
+            0,
+            descriptor.width(),
+            "Cannot allocate an array with 0 Width"
+        );
+
+        if !descriptor.flags().layered() && descriptor.depth() > 0 {
+            assert_ne!(
+                0,
+                descriptor.height(),
+                "If Depth is non-zero and the descriptor is not LAYERED, then Height must also be \
+                 non-zero."
+            );
+        }
+
+        if descriptor.flags().cubemap() {
+            assert_eq!(
+                descriptor.height(),
+                descriptor.width(),
+                "Height and Width must be equal for CUBEMAP arrays."
+            );
+
+            if descriptor.flags().layered() {
+                assert_eq!(
+                    0,
+                    descriptor.depth() % 6,
+                    "Depth must be a multiple of 6 when the array descriptor is for a LAYERED \
+                     CUBEMAP."
+                );
+            } else {
+                assert_eq!(
+                    6,
+                    descriptor.depth(),
+                    "Depth must be equal to 6 when the array descriptor is for a CUBEMAP."
+                );
+            }
+        }
+
+        if descriptor.num_channels() != 1
+            && descriptor.num_channels() != 2
+            && descriptor.num_channels() != 4
+        {
+            panic!(
+                "NumChannels was set to {}. It must be 1, 2, or 4.",
+                descriptor.num_channels()
+            );
+        }
+
+        let mut handle = unsafe { std::mem::uninitialized() };
+        unsafe { cuda_sys::cuda::cuArray3DCreate_v2(&mut handle, &descriptor.desc) }.to_result()?;
+        Ok(Self { handle })
+    }
+
+    /// Gets the descriptor associated with this array.
+    pub fn descriptor(&self) -> CudaResult<ArrayDescriptor> {
+        let mut raw_descriptor = unsafe { std::mem::uninitialized() };
+        unsafe { cuda_sys::cuda::cuArray3DGetDescriptor_v2(&mut raw_descriptor, self.handle) }
+            .to_result()?;
+
+        Ok(ArrayDescriptor::from_raw(raw_descriptor))
+    }
+
+    /// Try to destroy an `ArrayObject`. Can fail - if it does, returns the CUDA error and the
+    /// un-destroyed array object
+    pub fn drop(array: ArrayObject) -> DropResult<ArrayObject> {
+        match unsafe { cuda_sys::cuda::cuArrayDestroy(array.handle) }.to_result() {
+            Ok(()) => Ok(()),
+            Err(e) => Err((e, array)),
+        }
+    }
+}
+
+impl std::fmt::Debug for ArrayObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.descriptor().fmt(f)
+    }
+}
+
+impl Drop for ArrayObject {
+    fn drop(&mut self) {
+        unsafe { cuda_sys::cuda::cuArrayDestroy(self.handle) }
+            .to_result()
+            .expect("Failed to destroy CUDA Array")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn descriptor_round_trip() {
+        let _context = crate::quick_init().unwrap();
+
+        let obj = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([1, 2, 3], ArrayFormat::Float).with_num_channels(2),
+        )
+        .unwrap();
+
+        let descriptor = obj.descriptor().unwrap();
+        assert_eq!([1, 2, 3], descriptor.dims());
+        assert_eq!(ArrayFormat::Float, descriptor.format());
+        assert_eq!(2, descriptor.num_channels());
+        assert_eq!(ArrayObjectFlags::default(), descriptor.flags());
+    }
+
+    #[test]
+    fn allow_1d_arrays() {
+        let _context = crate::quick_init().unwrap();
+
+        let obj = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
+            [10, 0, 0],
+            ArrayFormat::Float,
+        ))
+        .unwrap();
+
+        let descriptor = obj.descriptor().unwrap();
+        assert_eq!([10, 0, 0], descriptor.dims());
+    }
+
+    #[test]
+    fn allow_2d_arrays() {
+        let _context = crate::quick_init().unwrap();
+
+        let obj = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
+            [10, 20, 0],
+            ArrayFormat::Float,
+        ))
+        .unwrap();
+
+        let descriptor = obj.descriptor().unwrap();
+        assert_eq!([10, 20, 0], descriptor.dims());
+    }
+
+    #[test]
+    fn allow_1d_layered_arrays() {
+        let _context = crate::quick_init().unwrap();
+
+        let obj = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([10, 0, 20], ArrayFormat::Float)
+                .with_flags(ArrayObjectFlags::LAYERED),
+        )
+        .unwrap();
+
+        let descriptor = obj.descriptor().unwrap();
+        assert_eq!([10, 0, 20], descriptor.dims());
+        assert_eq!(ArrayObjectFlags::LAYERED, descriptor.flags());
+    }
+
+    #[test]
+    fn allow_cubemaps() {
+        let _context = crate::quick_init().unwrap();
+
+        let obj = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([4, 4, 6], ArrayFormat::Float)
+                .with_flags(ArrayObjectFlags::CUBEMAP),
+        )
+        .unwrap();
+
+        let descriptor = obj.descriptor().unwrap();
+        assert_eq!([4, 4, 6], descriptor.dims());
+        assert_eq!(ArrayObjectFlags::CUBEMAP, descriptor.flags());
+    }
+
+    #[test]
+    fn allow_layered_cubemaps() {
+        let _context = crate::quick_init().unwrap();
+
+        let obj = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([4, 4, 24], ArrayFormat::Float)
+                .with_flags(ArrayObjectFlags::new().mark_layered().mark_cubemap()),
+        )
+        .unwrap();
+
+        let descriptor = obj.descriptor().unwrap();
+        assert_eq!([4, 4, 24], descriptor.dims());
+        assert_eq!(
+            ArrayObjectFlags::CUBEMAP | ArrayObjectFlags::LAYERED,
+            descriptor.flags()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "\
+assertion failed: `(left != right)`
+  left: `0`,
+ right: `0`: Cannot allocate an array with 0 Width")]
+    fn fail_on_zero_size_widths() {
+        let _context = crate::quick_init().unwrap();
+
+        let _ = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
+            [0, 10, 20],
+            ArrayFormat::Float,
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "\
+assertion failed: `(left == right)`
+  left: `3`,
+ right: `2`: Height and Width must be equal for CUBEMAP arrays.")]
+    fn fail_cubemaps_with_unmatching_width_height() {
+        let _context = crate::quick_init().unwrap();
+
+        let _ = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([2, 3, 6], ArrayFormat::Float)
+                .with_flags(ArrayObjectFlags::CUBEMAP),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "\
+assertion failed: `(left == right)`
+  left: `6`,
+ right: `5`: Depth must be equal to 6 when the array descriptor is for a CUBEMAP.")]
+    fn fail_cubemaps_with_non_six_depth() {
+        let _context = crate::quick_init().unwrap();
+
+        let _ = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([4, 4, 5], ArrayFormat::Float)
+                .with_flags(ArrayObjectFlags::CUBEMAP),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "\
+assertion failed: `(left == right)`
+  left: `0`,
+ right: `4`: Depth must be a multiple of 6 when the array descriptor is for a LAYERED CUBEMAP.")]
+    fn fail_cubemaps_with_non_six_multiple_depth() {
+        let _context = crate::quick_init().unwrap();
+
+        let _ = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([4, 4, 10], ArrayFormat::Float)
+                .with_flags(ArrayObjectFlags::LAYERED | ArrayObjectFlags::CUBEMAP),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "\
+assertion failed: `(left != right)`
+  left: `0`,
+ right: `0`: If Depth is non-zero and the descriptor is not LAYERED, then Height must also be \
+             non-zero.")]
+    fn fail_with_depth_without_height() {
+        let _context = crate::quick_init().unwrap();
+
+        let _ = ArrayObject::from_descriptor(ArrayDescriptor::from_dims_format(
+            [10, 0, 20],
+            ArrayFormat::Float,
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "NumChannels was set to 3. It must be 1, 2, or 4.")]
+    fn fails_on_invalid_num_channels() {
+        let _context = crate::quick_init().unwrap();
+
+        let _ = ArrayObject::from_descriptor(
+            ArrayDescriptor::from_dims_format([1, 2, 3], ArrayFormat::Float).with_num_channels(3),
+        )
+        .unwrap();
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -65,13 +65,13 @@
 //! responsible for reconstructing the `UnifiedBuffer` using `from_raw_parts()` and dropping it to
 //! ensure that the memory allocation is safely cleaned up.
 
-mod array;
+pub mod array;
+
 mod device;
 mod locked;
 mod malloc;
 mod unified;
 
-pub use self::array::*;
 pub use self::device::*;
 pub use self::locked::*;
 pub use self::malloc::*;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -65,11 +65,13 @@
 //! responsible for reconstructing the `UnifiedBuffer` using `from_raw_parts()` and dropping it to
 //! ensure that the memory allocation is safely cleaned up.
 
+mod array;
 mod device;
 mod locked;
 mod malloc;
 mod unified;
 
+pub use self::array::*;
 pub use self::device::*;
 pub use self::locked::*;
 pub use self::malloc::*;


### PR DESCRIPTION
Work towards addressing #10.

See the commit message below for precise list of what's currently implemented. This currently just implements the creation of "generic" CUDA Arrays. Before we merge,I'd like to add typed CUDA arrays that support copy-from-host using typed slices and (as an optional feature) ndarrays.

If you could, please look at the `ArrayObject::from_descriptor` routine. I try to exhaustively validate the preconditions of `cuArray3DCreate_v2` (documentation [here](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEM.html#group__CUDA__MEM_1gc2322c70b38c2984536c90ed118bb1d7)). Perhaps controversially, it panics when the preconditions are violated. The nice thing here is the user gets a pretty specific error message (did not set value "foo" to a valid value). The downside is that the user cannot handle the error. IMO, all of the precondition violations are essentially "unrecoverable". i.e., if you fall into this case, it's most likely a code bug and not something the user code is probably capable of handling anyway.

I did validate that all of these conditions are caught by CUDA and returned as `CudaError::InvalidValue`, so we could defer to CUDA to validate the parameters, though the error message is vague.

Initial commit message:
The primary new type is ArrayObject, which represents a generic array
with up to 3-dimensions.

An ArrayObject has a set of dimensions, an ArrayFormat, a number of
channels (1, 2, or 4), and a set of ArrayObjectFlags

Adds tests that assert correct ArrayObject values are accepted and that
bad ones are rejected with a panic.