### PR TITLE
Fix compile error on ppc64 architecture

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -312,7 +312,12 @@ impl Device {
     pub fn name(self) -> CudaResult<String> {
         unsafe {
             let mut name = [0u8; 128]; // Hopefully this is big enough...
-            cuDeviceGetName(&mut name[0] as *mut u8 as *mut i8, 128, self.device).to_result()?;
+            cuDeviceGetName(
+                &mut name[0] as *mut u8 as *mut ::std::os::raw::c_char,
+                128,
+                self.device,
+            )
+            .to_result()?;
             let cstr = CStr::from_bytes_with_nul_unchecked(&name);
             Ok(cstr.to_string_lossy().into_owned())
         }


### PR DESCRIPTION
RustaCUDA currently doesn't compile on PPC64 architecture. The reason is that, [according to the Rust documentation](https://doc.rust-lang.org/std/os/raw/type.c_char.html), `std::os::raw::c_char` can be defined in one of two ways: either as `i8`, or as `u8`.

Coincidentally, x86_64 defines it as `i8`, whereas PPC64 defines it as `u8`. This difference breaks the type cast in `device::Device::name`.

Casting to `c_char` instead of `i8` solves the problem. With this fix, RustaCUDA compiles on PPC64.