### PR TITLE
Fix memory over-allocation bugs

### DIFF
--- a/src/memory/device/device_buffer.rs
+++ b/src/memory/device/device_buffer.rs
@@ -459,4 +459,22 @@ mod test_device_buffer {
             let _slice = &buffer[0..5];
         }
     }
+
+    #[test]
+    fn test_allocate_correct_size() {
+        use crate::context::CurrentContext;
+
+        let _context = crate::quick_init().unwrap();
+        let total_memory = CurrentContext::get_device()
+            .unwrap()
+            .total_memory()
+            .unwrap();
+
+        // Don't allocate all memory to leave some space for the display's frame buffer
+        let allocation_size = (total_memory * 3) / 4 / mem::size_of::<u64>();
+        unsafe {
+            // Test if allocation fails with an out-of-memory error
+            let _buffer = DeviceBuffer::<u64>::uninitialized(allocation_size).unwrap();
+        };
+    }
 }

--- a/src/memory/device/device_buffer.rs
+++ b/src/memory/device/device_buffer.rs
@@ -1,4 +1,4 @@
-use crate::error::{CudaError, CudaResult, DropResult, ToResult};
+use crate::error::{CudaResult, DropResult, ToResult};
 use crate::memory::device::{AsyncCopyDestination, CopyDestination, DeviceSlice};
 use crate::memory::malloc::{cuda_free, cuda_malloc};
 use crate::memory::DeviceCopy;
@@ -39,12 +39,8 @@ impl<T> DeviceBuffer<T> {
     /// buffer.copy_from(&[0u64, 1, 2, 3, 4]).unwrap();
     /// ```
     pub unsafe fn uninitialized(size: usize) -> CudaResult<Self> {
-        let bytes = size
-            .checked_mul(mem::size_of::<T>())
-            .ok_or(CudaError::InvalidMemoryAllocation)?;
-
-        let ptr = if bytes > 0 {
-            cuda_malloc(bytes)?
+        let ptr = if size > 0 && mem::size_of::<T>() > 0 {
+            cuda_malloc(size)?
         } else {
             DevicePointer::wrap(ptr::NonNull::dangling().as_ptr() as *mut T)
         };
@@ -79,12 +75,8 @@ impl<T> DeviceBuffer<T> {
     /// assert_eq!([0u64, 0, 0, 0, 0], host_values);
     /// ```
     pub unsafe fn zeroed(size: usize) -> CudaResult<Self> {
-        let bytes = size
-            .checked_mul(mem::size_of::<T>())
-            .ok_or(CudaError::InvalidMemoryAllocation)?;
-
-        let ptr = if bytes > 0 {
-            let mut ptr = cuda_malloc(bytes)?;
+        let ptr = if size > 0 && mem::size_of::<T>() > 0 {
+            let mut ptr = cuda_malloc(size)?;
             cuda::cuMemsetD8_v2(ptr.as_raw_mut() as u64, 0, size * mem::size_of::<T>())
                 .to_result()?;
             ptr

--- a/src/memory/locked.rs
+++ b/src/memory/locked.rs
@@ -93,12 +93,8 @@ impl<T: DeviceCopy> LockedBuffer<T> {
     /// }
     /// ```
     pub unsafe fn uninitialized(size: usize) -> CudaResult<Self> {
-        let bytes = size
-            .checked_mul(mem::size_of::<T>())
-            .ok_or(CudaError::InvalidMemoryAllocation)?;
-
-        let ptr: *mut T = if bytes > 0 {
-            cuda_malloc_locked(bytes)?
+        let ptr: *mut T = if size > 0 && mem::size_of::<T>() > 0 {
+            cuda_malloc_locked(size)?
         } else {
             ptr::NonNull::dangling().as_ptr()
         };

--- a/src/memory/locked.rs
+++ b/src/memory/locked.rs
@@ -332,4 +332,16 @@ mod test {
         let err = LockedBuffer::new(&0u64, ::std::usize::MAX - 1).unwrap_err();
         assert_eq!(CudaError::InvalidMemoryAllocation, err);
     }
+
+    #[test]
+    fn test_allocate_correct_size() {
+        let _context = crate::quick_init().unwrap();
+
+        // Placeholder - read out available system memory here
+        let allocation_size = 1;
+        unsafe {
+            // Test if allocation fails with an out-of-memory error
+            let _buffer = LockedBuffer::<u64>::uninitialized(allocation_size).unwrap();
+        }
+    }
 }

--- a/src/memory/unified.rs
+++ b/src/memory/unified.rs
@@ -408,12 +408,8 @@ impl<T: DeviceCopy> UnifiedBuffer<T> {
     /// }
     /// ```
     pub unsafe fn uninitialized(size: usize) -> CudaResult<Self> {
-        let bytes = size
-            .checked_mul(mem::size_of::<T>())
-            .ok_or(CudaError::InvalidMemoryAllocation)?;
-
-        let ptr = if bytes > 0 {
-            cuda_malloc_unified(bytes)?
+        let ptr = if size > 0 && mem::size_of::<T>() > 0 {
+            cuda_malloc_unified(size)?
         } else {
             UnifiedPointer::wrap(ptr::NonNull::dangling().as_ptr() as *mut T)
         };

--- a/src/memory/unified.rs
+++ b/src/memory/unified.rs
@@ -719,4 +719,22 @@ mod test_unified_buffer {
         let err = UnifiedBuffer::new(&0u64, ::std::usize::MAX - 1).unwrap_err();
         assert_eq!(CudaError::InvalidMemoryAllocation, err);
     }
+
+    #[test]
+    fn test_allocate_correct_size() {
+        use crate::context::CurrentContext;
+
+        let _context = crate::quick_init().unwrap();
+        let total_memory = CurrentContext::get_device()
+            .unwrap()
+            .total_memory()
+            .unwrap();
+
+        // Don't allocate all memory to leave some space for the display's frame buffer
+        let allocation_size = (total_memory * 3) / 4 / mem::size_of::<u64>();
+        unsafe {
+            // Test if allocation fails with an out-of-memory error
+            let _buffer = UnifiedBuffer::<u64>::uninitialized(allocation_size).unwrap();
+        }
+    }
 }


### PR DESCRIPTION
`DeviceBuffer`, `LockedBuffer`, and `UnifiedBuffer` allocate several times more memory than requested.
For example:
```
DeviceBuffer::zeroed::<i64>(2_usize.pow(30))
```
allocates 8 GB instead of the requested 1 GB. This can result in an unexpected OutOfMemory error.

The bugs occur because the respective `*_malloc()` wrappers already account for the scaling from "count of T" to bytes. Thus, count is multiplied with `size_of::<T>()` twice.

This fix simply removes the superfluous multiplications.