### PR TITLE
Manually implement traits for pointer types

### DIFF
--- a/rustacuda_core/src/memory/pointer.rs
+++ b/rustacuda_core/src/memory/pointer.rs
@@ -30,9 +30,6 @@ macro_rules! derive_traits {
             fn eq(&self, other: &$Ptr) -> bool {
                 PartialEq::eq(&self.0, &other.0)
             }
-            fn ne(&self, other: &$Ptr) -> bool {
-                PartialEq::ne(&self.0, &other.0)
-            }
         }
 
         impl<T: ?Sized> Eq for $Ptr {}


### PR DESCRIPTION
Deriving generates code like

```
impl<T: Trait> Trait for DevicePointer<T>
```

But pointer primitives in `std` do not constraint like that.