### PR TITLE
Fix the Continuous Integration

### DIFF
--- a/rustacuda_core/src/memory/mod.rs
+++ b/rustacuda_core/src/memory/mod.rs
@@ -20,8 +20,6 @@ use core::num::*;
 ///
 /// #[derive(Clone, DeviceCopy)]
 /// struct MyStruct(u64);
-///
-/// # fn main() {}
 /// ```
 ///
 /// This is safe because the `DeviceCopy` derive macro will check that all fields of the struct,
@@ -33,7 +31,6 @@ use core::num::*;
 /// # extern crate rustacuda;
 /// #[derive(Clone, DeviceCopy)]
 /// struct MyStruct(Vec<u64>);
-/// # fn main() {}
 /// ```
 ///
 /// You can also implement `DeviceCopy` unsafely:

--- a/rustacuda_core/src/memory/pointer.rs
+++ b/rustacuda_core/src/memory/pointer.rs
@@ -20,7 +20,7 @@ unsafe impl<T> DeviceCopy for DevicePointer<T> {}
 impl<T> DevicePointer<T> {
     /// Returns a null device pointer.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -40,7 +40,7 @@ impl<T> DevicePointer<T> {
     /// The given pointer must have been allocated with [`cuda_malloc`](fn.cuda_malloc.html) or
     /// be null.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -58,7 +58,7 @@ impl<T> DevicePointer<T> {
     /// Returns the contained pointer as a raw pointer. The returned pointer is not valid on the CPU
     /// and must not be dereferenced.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -76,7 +76,7 @@ impl<T> DevicePointer<T> {
     /// Returns the contained pointer as a mutable raw pointer. The returned pointer is not valid on the CPU
     /// and must not be dereferenced.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -92,7 +92,7 @@ impl<T> DevicePointer<T> {
     }
 
     /// Returns true if the pointer is null.
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -353,7 +353,7 @@ unsafe impl<T: DeviceCopy> DeviceCopy for UnifiedPointer<T> {}
 impl<T: DeviceCopy> UnifiedPointer<T> {
     /// Returns a null unified pointer.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -373,7 +373,7 @@ impl<T: DeviceCopy> UnifiedPointer<T> {
     /// The given pointer must have been allocated with
     /// [`cuda_malloc_unified`](fn.cuda_malloc_unified.html) or be null.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -390,7 +390,7 @@ impl<T: DeviceCopy> UnifiedPointer<T> {
 
     /// Returns the contained pointer as a raw pointer.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -407,7 +407,7 @@ impl<T: DeviceCopy> UnifiedPointer<T> {
 
     /// Returns the contained pointer as a mutable raw pointer.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -425,7 +425,7 @@ impl<T: DeviceCopy> UnifiedPointer<T> {
 
     /// Returns true if the pointer is null.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -32,7 +32,7 @@
 //! functions. The programmer must ensure that no other OS threads are using the `Context` when it
 //! is dropped.
 //!
-//! # Examples:
+//! # Examples
 //!
 //! For most commmon uses (one device, one OS thread) it should suffice to create a single context:
 //!
@@ -242,7 +242,7 @@ pub struct Context {
 impl Context {
     /// Create a CUDA context for the given device.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -276,7 +276,7 @@ impl Context {
     ///
     /// This is not necessarily the latest version supported by the driver.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -306,7 +306,7 @@ impl Context {
     /// This is useful for sharing a single context between threads (though see the module-level
     /// documentation for safety details!).
     ///
-    /// # Example:
+    /// # Example
     ////*  */
     /// ```
     /// # use rustacuda::device::Device;
@@ -330,7 +330,7 @@ impl Context {
     /// Destroying a context can return errors from previous asynchronous work. This function
     /// destroys the given context and returns the error and the un-destroyed context on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -414,7 +414,7 @@ impl UnownedContext {
     ///
     /// This is not necessarily the latest version supported by the driver.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -449,7 +449,7 @@ impl ContextStack {
     /// Pop the current context off the stack and return the handle. That context may then be made
     /// current again (perhaps on a different CPU thread) by calling [push](#method.push).
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -475,7 +475,7 @@ impl ContextStack {
 
     /// Push the given context to the top of the stack
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -522,7 +522,7 @@ impl CurrentContext {
     /// where the size of the L1 cache and shared memory are fixed, this will always return
     /// `CacheConfig::PreferNone`.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -548,7 +548,7 @@ impl CurrentContext {
 
     /// Return the device ID for the current context.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -573,7 +573,7 @@ impl CurrentContext {
 
     /// Return the context flags for the current context.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -598,7 +598,7 @@ impl CurrentContext {
 
     /// Return resource limits for the current context.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -623,7 +623,7 @@ impl CurrentContext {
 
     /// Return resource limits for the current context.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -655,7 +655,7 @@ impl CurrentContext {
     /// automatically clamped to within the valid range. If the device does not support stream
     /// priorities, the returned range will contain zeroes.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -695,7 +695,7 @@ impl CurrentContext {
     /// This setting does nothing on devices where the size of the L1 cache and shared memory are
     /// fixed.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -739,7 +739,7 @@ impl CurrentContext {
     /// * `MaxL2FetchGranularity`: Controls the L2 fetch granularity. This is purely a performance
     ///    hint and it can be ignored or clamped depending on the platform.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -766,7 +766,7 @@ impl CurrentContext {
     /// On devices with configurable shared memory banks, this function will set the context's
     /// shared memory bank size which is used for subsequent kernel launches.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -787,7 +787,7 @@ impl CurrentContext {
 
     /// Returns a non-owning handle to the current context.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;
@@ -816,7 +816,7 @@ impl CurrentContext {
     /// If there is a context set for this thread, this replaces the top context on the stack with
     /// the given context.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::device::Device;

--- a/src/derive_compile_fail.rs
+++ b/src/derive_compile_fail.rs
@@ -8,8 +8,6 @@
 //!
 //! #[derive(Clone, DeviceCopy)]
 //! struct ShouldFailTuple(Vec<u64>);
-//!
-//! fn main() {}
 //! ```
 //!
 //! ```compile_fail
@@ -19,8 +17,6 @@
 //!
 //! #[derive(Clone, DeviceCopy)]
 //! struct ShouldFailStruct{v: Vec<u64>}
-//!
-//! fn main() {}
 //! ```
 //!
 //! ```compile_fail
@@ -33,8 +29,6 @@
 //!     Unit,
 //!     Tuple(Vec<u64>),
 //! }
-//!
-//! fn main() {}
 //! ```
 //!
 //! ```compile_fail
@@ -47,8 +41,6 @@
 //!     Unit,
 //!     Struct{v: Vec<u64>},
 //! }
-//!
-//! fn main() {}
 //! ```
 //!
 //! ```compile_fail
@@ -61,6 +53,4 @@
 //!     u: *const u64,
 //!     o: *const i64,
 //! }
-//!
-//! fn main() {}
 //! ```

--- a/src/device.rs
+++ b/src/device.rs
@@ -207,7 +207,7 @@ impl Device {
     /// Returns the number of devices with compute-capability 2.0 or greater which are available
     /// for execution.
     ///
-    /// # Example:
+    /// # Example
     /// ```
     /// # use rustacuda::*;
     /// # use std::error::Error;
@@ -231,7 +231,7 @@ impl Device {
     ///
     /// Ordinal must be in the range `0..num_devices()`. If not, an error will be returned.
     ///
-    /// # Example:
+    /// # Example
     /// ```
     /// # use rustacuda::*;
     /// # use std::error::Error;
@@ -253,7 +253,7 @@ impl Device {
 
     /// Return an iterator over all CUDA devices.
     ///
-    /// # Example:
+    /// # Example
     /// ```
     /// # use rustacuda::*;
     /// # use std::error::Error;
@@ -275,7 +275,7 @@ impl Device {
 
     /// Returns the total amount of memory available on the device in bytes.
     ///
-    /// # Example:
+    /// # Example
     /// ```
     /// # use rustacuda::*;
     /// # use std::error::Error;
@@ -297,7 +297,7 @@ impl Device {
 
     /// Returns the name of this device.
     ///
-    /// # Example:
+    /// # Example
     /// ```
     /// # use rustacuda::*;
     /// # use std::error::Error;
@@ -330,7 +330,7 @@ impl Device {
 
     /// Returns information about this device.
     ///
-    /// # Example:
+    /// # Example
     /// ```
     /// # use rustacuda::*;
     /// # use std::error::Error;

--- a/src/event.rs
+++ b/src/event.rs
@@ -69,7 +69,7 @@ pub struct Event(CUevent);
 impl Event {
     /// Create a new event with the specified flags.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::quick_init;
@@ -295,7 +295,7 @@ impl Event {
     /// This function destroys the given event and returns the error and the
     /// un-destroyed event on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::*;

--- a/src/function.rs
+++ b/src/function.rs
@@ -169,7 +169,7 @@ impl<'a> Function<'a> {
 
     /// Returns information about a function.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -213,7 +213,7 @@ impl<'a> Function<'a> {
     /// This setting does nothing on devices where the size of the L1 cache and shared memory are
     /// fixed.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::*;
@@ -241,7 +241,7 @@ impl<'a> Function<'a> {
     /// shared memory bank size which is used for subsequent launches of this function. If not set,
     /// the context-wide setting will be used instead.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::*;
@@ -301,7 +301,7 @@ impl<'a> Function<'a> {
 /// In this variant, the `function` parameter must be a variable. Use this form to avoid looking up
 /// the kernel function for each call.
 ///
-/// # Safety:
+/// # Safety
 ///
 /// Launching kernels must be done in an `unsafe` block. Calling a kernel is similar to calling a
 /// foreign-language function, as the kernel itself could be written in C or unsafe Rust. The kernel
@@ -310,7 +310,7 @@ impl<'a> Function<'a> {
 /// be copied back to the host. The programmer must ensure that the host does not access device or
 /// unified memory that the kernel could write to until after calling `stream.synchronize()`.
 ///
-/// # Examples:
+/// # Examples
 ///
 /// ```
 /// # #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! export CUDA_LIBRARY_PATH="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v9.1\lib\x64"
 //! ```
 //!
-//! # Examples:
+//! # Examples
 //!
 //! ## Adding two numbers on the device:
 //!

--- a/src/memory/array.rs
+++ b/src/memory/array.rs
@@ -376,7 +376,7 @@ impl ArrayObject {
             }
         }
 
-        let mut handle = unsafe { std::mem::uninitialized() };
+        let mut handle = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
         unsafe { cuda_sys::cuda::cuArray3DCreate_v2(&mut handle, &descriptor.desc) }.to_result()?;
         Ok(Self { handle })
     }
@@ -624,7 +624,7 @@ impl ArrayObject {
 
     /// Gets the descriptor associated with this array.
     pub fn descriptor(&self) -> CudaResult<ArrayDescriptor> {
-        let mut raw_descriptor = unsafe { std::mem::uninitialized() };
+        let mut raw_descriptor = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
         unsafe { cuda_sys::cuda::cuArray3DGetDescriptor_v2(&mut raw_descriptor, self.handle) }
             .to_result()?;
 

--- a/src/memory/device/device_box.rs
+++ b/src/memory/device/device_box.rs
@@ -23,11 +23,11 @@ impl<T: DeviceCopy> DeviceBox<T> {
     ///
     /// This doesn't actually allocate if `T` is zero-sized.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If a CUDA error occurs, return the error.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -45,13 +45,13 @@ impl<T> DeviceBox<T> {
     ///
     /// This doesn't actually allocate if `T` is zero-sized.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// Since the backing memory is not initialized, this function is not safe. The caller must
     /// ensure that the backing memory is set to a valid value before it is read, else undefined
     /// behavior may occur.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -74,13 +74,13 @@ impl<T> DeviceBox<T> {
     ///
     /// This doesn't actually allocate if `T` is zero-sized.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// The backing memory is zeroed, which may not be a valid bit-pattern for type `T`. The caller
     /// must ensure either that all-zeroes is a valid bit-pattern for type `T` or that the backing
     /// memory is set to a valid value before it is read.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -110,13 +110,13 @@ impl<T> DeviceBox<T> {
     /// of `T`. This function may accept any pointer produced by the `cuMemAllocManaged` CUDA API
     /// call.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// This function is unsafe because improper use may lead to memory problems. For example, a
     /// double free may occur if this function is called twice on the same pointer, or a segfault
     /// may occur if the pointer is not one returned by the appropriate API call.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -138,13 +138,13 @@ impl<T> DeviceBox<T> {
     /// of `T`. This function may accept any pointer produced by the `cuMemAllocManaged` CUDA API
     /// call, such as one taken from `DeviceBox::into_device`.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// This function is unsafe because improper use may lead to memory problems. For example, a
     /// double free may occur if this function is called twice on the same pointer, or a segfault
     /// may occur if the pointer is not one returned by the appropriate API call.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -167,7 +167,7 @@ impl<T> DeviceBox<T> {
     /// `DeviceBox::into_device(b)` instead of `b.into_device()` This is so that there is no conflict with
     /// a method on the inner type.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -187,7 +187,7 @@ impl<T> DeviceBox<T> {
     ///
     /// This is useful for passing the box to a kernel launch.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -205,7 +205,7 @@ impl<T> DeviceBox<T> {
     /// Deallocating device memory can return errors from previous asynchronous work. This function
     /// destroys the given box and returns the error and the un-destroyed box on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();

--- a/src/memory/device/device_buffer.rs
+++ b/src/memory/device/device_buffer.rs
@@ -198,7 +198,7 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     /// with a clone of the data in `slice`.
     ///
     /// # Safety
-    /// 
+    ///
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
     /// # Errors

--- a/src/memory/device/device_buffer.rs
+++ b/src/memory/device/device_buffer.rs
@@ -197,6 +197,8 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     /// Asynchronously allocate a new buffer of the same size as `slice`, initialized
     /// with a clone of the data in `slice`.
     ///
+    /// # Safety
+    /// 
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
     /// # Errors

--- a/src/memory/device/device_buffer.rs
+++ b/src/memory/device/device_buffer.rs
@@ -20,17 +20,17 @@ impl<T> DeviceBuffer<T> {
     /// Allocate a new device buffer large enough to hold `size` `T`'s, but without
     /// initializing the contents.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA. If `size` is large enough that
     /// `size * mem::sizeof::<T>()` overflows usize, then returns InvalidMemoryAllocation.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// The caller must ensure that the contents of the buffer are initialized before reading from
     /// the buffer.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -53,18 +53,18 @@ impl<T> DeviceBuffer<T> {
     /// Allocate a new device buffer large enough to hold `size` `T`'s and fill the contents with
     /// zeroes (`0u8`).
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA. If `size` is large enough that
     /// `size * mem::sizeof::<T>()` overflows usize, then returns InvalidMemoryAllocation.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// The backing memory is zeroed, which may not be a valid bit-pattern for type `T`. The caller
     /// must ensure either that all-zeroes is a valid bit-pattern for type `T` or that the backing
     /// memory is set to a valid value before it is read.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -110,7 +110,7 @@ impl<T> DeviceBuffer<T> {
     /// that nothing else uses the pointer after calling this
     /// function.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -134,7 +134,7 @@ impl<T> DeviceBuffer<T> {
     /// Deallocating device memory can return errors from previous asynchronous work. This function
     /// destroys the given buffer and returns the error and the un-destroyed buffer on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -174,11 +174,11 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     /// Allocate a new device buffer of the same size as `slice`, initialized with a clone of
     /// the data in `slice`.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -199,11 +199,11 @@ impl<T: DeviceCopy> DeviceBuffer<T> {
     ///
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();

--- a/src/memory/device/device_slice.rs
+++ b/src/memory/device/device_slice.rs
@@ -169,7 +169,7 @@ impl<T> DeviceSlice<T> {
     ///
     /// Panics if `chunk_size` is 0.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -201,7 +201,7 @@ impl<T> DeviceSlice<T> {
     ///
     /// Panics if `chunk_size` is 0.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();

--- a/src/memory/device/device_slice.rs
+++ b/src/memory/device/device_slice.rs
@@ -291,13 +291,13 @@ impl<T> DeviceSlice<T> {
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
     /// elements, nor whether the lifetime inferred is a suitable lifetime for the returned slice.
-    /// 
+    ///
     /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
     /// elements, not whether the lifetime inferred is a suitable lifetime for the returned slice,
     /// as well as not being able to provide a non-aliasing guarantee of the returned
     /// mutable slice. `data` must be non-null and aligned even for zero-length
     /// slices as with `from_raw_parts`.
-    /// 
+    ///
     /// See the documentation of `from_raw_parts` for more details.
     pub unsafe fn from_raw_parts_mut<'a>(
         mut data: DevicePointer<T>,

--- a/src/memory/device/device_slice.rs
+++ b/src/memory/device/device_slice.rs
@@ -287,11 +287,18 @@ impl<T> DeviceSlice<T> {
     /// Performs the same functionality as `from_raw_parts`, except that a
     /// mutable slice is returned.
     ///
-    /// This function is unsafe for the same reasons as `from_raw_parts`, as well
-    /// as not being able to provide a non-aliasing guarantee of the returned
+    /// # Safety
+    ///
+    /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
+    /// elements, nor whether the lifetime inferred is a suitable lifetime for the returned slice.
+    /// 
+    /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
+    /// elements, not whether the lifetime inferred is a suitable lifetime for the returned slice,
+    /// as well as not being able to provide a non-aliasing guarantee of the returned
     /// mutable slice. `data` must be non-null and aligned even for zero-length
-    /// slices as with `from_raw_parts`. See the documentation of
-    /// `from_raw_parts` for more details.
+    /// slices as with `from_raw_parts`.
+    /// 
+    /// See the documentation of `from_raw_parts` for more details.
     pub unsafe fn from_raw_parts_mut<'a>(
         mut data: DevicePointer<T>,
         len: usize,

--- a/src/memory/device/mod.rs
+++ b/src/memory/device/mod.rs
@@ -50,6 +50,8 @@ pub trait AsyncCopyDestination<O: ?Sized>: crate::private::Sealed {
     ///
     /// Host memory used as a source or destination must be page-locked.
     ///
+    /// # Safety
+    /// 
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
     /// # Errors
@@ -61,6 +63,8 @@ pub trait AsyncCopyDestination<O: ?Sized>: crate::private::Sealed {
     ///
     /// Host memory used as a source or destination must be page-locked.
     ///
+    /// # Safety
+    /// 
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
     /// # Errors

--- a/src/memory/device/mod.rs
+++ b/src/memory/device/mod.rs
@@ -14,14 +14,14 @@ pub use self::device_slice::*;
 pub trait CopyDestination<O: ?Sized>: crate::private::Sealed {
     /// Copy data from `source`. `source` must be the same size as `self`.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If a CUDA error occurs, return the error.
     fn copy_from(&mut self, source: &O) -> CudaResult<()>;
 
     /// Copy data to `dest`. `dest` must be the same size as `self`.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If a CUDA error occurs, return the error.
     fn copy_to(&self, dest: &mut O) -> CudaResult<()>;
@@ -30,7 +30,7 @@ pub trait CopyDestination<O: ?Sized>: crate::private::Sealed {
 /// Sealed trait implemented by types which can be the source or destination when copying data
 /// asynchronously to/from the device or from one device allocation to another.
 ///
-/// ## Safety:
+/// # Safety
 ///
 /// The functions of this trait are unsafe because they return control to the calling code while
 /// the copy operation could still be occurring in the background. This could allow calling code
@@ -52,7 +52,7 @@ pub trait AsyncCopyDestination<O: ?Sized>: crate::private::Sealed {
     ///
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If a CUDA error occurs, return the error.
     unsafe fn async_copy_from(&mut self, source: &O, stream: &Stream) -> CudaResult<()>;
@@ -63,7 +63,7 @@ pub trait AsyncCopyDestination<O: ?Sized>: crate::private::Sealed {
     ///
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If a CUDA error occurs, return the error.
     unsafe fn async_copy_to(&self, dest: &mut O, stream: &Stream) -> CudaResult<()>;

--- a/src/memory/device/mod.rs
+++ b/src/memory/device/mod.rs
@@ -51,7 +51,7 @@ pub trait AsyncCopyDestination<O: ?Sized>: crate::private::Sealed {
     /// Host memory used as a source or destination must be page-locked.
     ///
     /// # Safety
-    /// 
+    ///
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
     /// # Errors
@@ -64,7 +64,7 @@ pub trait AsyncCopyDestination<O: ?Sized>: crate::private::Sealed {
     /// Host memory used as a source or destination must be page-locked.
     ///
     /// # Safety
-    /// 
+    ///
     /// For why this function is unsafe, see [AsyncCopyDestination](trait.AsyncCopyDestination.html)
     ///
     /// # Errors

--- a/src/memory/locked.rs
+++ b/src/memory/locked.rs
@@ -19,12 +19,12 @@ impl<T: DeviceCopy + Clone> LockedBuffer<T> {
     /// Allocate a new page-locked buffer large enough to hold `size` `T`'s and initialized with
     /// clones of `value`.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA. If `size` is large enough that
     /// `size * mem::sizeof::<T>()` overflows usize, then returns InvalidMemoryAllocation.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -45,11 +45,11 @@ impl<T: DeviceCopy + Clone> LockedBuffer<T> {
     /// Allocate a new page-locked buffer of the same size as `slice`, initialized with a clone of
     /// the data in `slice`.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -72,17 +72,17 @@ impl<T: DeviceCopy> LockedBuffer<T> {
     /// Allocate a new page-locked buffer large enough to hold `size` `T`'s, but without
     /// initializing the contents.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA. If `size` is large enough that
     /// `size * mem::sizeof::<T>()` overflows usize, then returns InvalidMemoryAllocation.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// The caller must ensure that the contents of the buffer are initialized before reading from
     /// the buffer.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -108,7 +108,7 @@ impl<T: DeviceCopy> LockedBuffer<T> {
     ///
     /// Equivalent to `&s[..]`.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -124,7 +124,7 @@ impl<T: DeviceCopy> LockedBuffer<T> {
     ///
     /// Equivalent to `&mut s[..]`.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -159,7 +159,7 @@ impl<T: DeviceCopy> LockedBuffer<T> {
     /// that nothing else uses the pointer after calling this
     /// function.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -186,7 +186,7 @@ impl<T: DeviceCopy> LockedBuffer<T> {
     /// Deallocating page-locked memory can return errors from previous asynchronous work. This function
     /// destroys the given buffer and returns the error and the un-destroyed buffer on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();

--- a/src/memory/unified.rs
+++ b/src/memory/unified.rs
@@ -26,11 +26,11 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     ///
     /// This doesn't actually allocate if `T` is zero-sized.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If a CUDA error occurs, returns that error.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -53,17 +53,17 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     ///
     /// This doesn't actually allocate if `T` is zero-sized.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// Since the backing memory is not initialized, this function is not safe. The caller must
     /// ensure that the backing memory is set to a valid value before it is read, else undefined
     /// behavior may occur.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If a CUDA error occurs, returns that error.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -89,13 +89,13 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     /// of `T`. This function may accept any pointer produced by the `cuMemAllocManaged` CUDA API
     /// call.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// This function is unsafe because improper use may lead to memory problems. For example, a
     /// double free may occur if this function is called twice on the same pointer, or a segfault
     /// may occur if the pointer is not one returned by the appropriate API call.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -117,13 +117,13 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     /// of `T`. This function may accept any pointer produced by the `cuMemAllocManaged` CUDA API
     /// call, such as one taken from `UnifiedBox::into_unified`.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// This function is unsafe because improper use may lead to memory problems. For example, a
     /// double free may occur if this function is called twice on the same pointer, or a segfault
     /// may occur if the pointer is not one returned by the appropriate API call.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -146,7 +146,7 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     /// `UnifiedBox::into_unified(b)` instead of `b.into_unified()` This is so that there is no conflict with
     /// a method on the inner type.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -166,7 +166,7 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     ///
     /// This is useful for passing the box to a kernel launch.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -203,7 +203,7 @@ impl<T: DeviceCopy> UnifiedBox<T> {
     /// Deallocating unified memory can return errors from previous asynchronous work. This function
     /// destroys the given box and returns the error and the un-destroyed box on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -334,12 +334,12 @@ impl<T: DeviceCopy + Clone> UnifiedBuffer<T> {
     /// Allocate a new unified buffer large enough to hold `size` `T`'s and initialized with
     /// clones of `value`.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA. If `size` is large enough that
     /// `size * mem::sizeof::<T>()` overflows usize, then returns InvalidMemoryAllocation.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -360,11 +360,11 @@ impl<T: DeviceCopy + Clone> UnifiedBuffer<T> {
     /// Allocate a new unified buffer of the same size as `slice`, initialized with a clone of
     /// the data in `slice`.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -387,17 +387,17 @@ impl<T: DeviceCopy> UnifiedBuffer<T> {
     /// Allocate a new unified buffer large enough to hold `size` `T`'s, but without
     /// initializing the contents.
     ///
-    /// # Errors:
+    /// # Errors
     ///
     /// If the allocation fails, returns the error from CUDA. If `size` is large enough that
     /// `size * mem::sizeof::<T>()` overflows usize, then returns InvalidMemoryAllocation.
     ///
-    /// # Safety:
+    /// # Safety
     ///
     /// The caller must ensure that the contents of the buffer are initialized before reading from
     /// the buffer.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -423,7 +423,7 @@ impl<T: DeviceCopy> UnifiedBuffer<T> {
     ///
     /// Equivalent to `&s[..]`.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -439,7 +439,7 @@ impl<T: DeviceCopy> UnifiedBuffer<T> {
     ///
     /// Equivalent to `&mut s[..]`.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -486,7 +486,7 @@ impl<T: DeviceCopy> UnifiedBuffer<T> {
     /// that nothing else uses the pointer after calling this
     /// function.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();
@@ -510,7 +510,7 @@ impl<T: DeviceCopy> UnifiedBuffer<T> {
     /// Deallocating unified memory can return errors from previous asynchronous work. This function
     /// destroys the given buffer and returns the error and the un-destroyed buffer on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # let _context = rustacuda::quick_init().unwrap();

--- a/src/module.rs
+++ b/src/module.rs
@@ -21,7 +21,7 @@ impl Module {
     /// The given file should be either a cubin file, a ptx file, or a fatbin file such as
     /// those produced by `nvcc`.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::*;
@@ -55,7 +55,7 @@ impl Module {
     /// The given CStr must contain the bytes of a cubin file, a ptx file or a fatbin file such as
     /// those produced by `nvcc`.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::*;
@@ -90,7 +90,7 @@ impl Module {
     ///
     /// This function panics if the size of the symbol is not the same as the `mem::sizeof<T>()`.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -133,7 +133,7 @@ impl Module {
 
     /// Get a reference to a kernel function which can then be launched.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -169,7 +169,7 @@ impl Module {
     /// Destroying a module can return errors from previous asynchronous work. This function
     /// destroys the given module and returns the error and the un-destroyed module on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::*;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -66,7 +66,7 @@ impl Stream {
     /// to get the range of valid priority values; if priority is set outside that range, it will
     /// be automatically clamped to the lowest or highest number in the range.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -100,7 +100,7 @@ impl Stream {
 
     /// Return the flags which were used to create this stream.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -128,7 +128,7 @@ impl Stream {
     /// If the stream was created with a priority outside the valid range, returns the clamped
     /// priority.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -161,7 +161,7 @@ impl Stream {
     /// The callback will be passed a `CudaResult<()>` indicating the
     /// current state of the device with `Ok(())` denoting normal operation.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -200,7 +200,7 @@ impl Stream {
     ///
     /// Waits until the device has completed all operations scheduled for this stream.
     ///
-    /// # Examples:
+    /// # Examples
     ///
     /// ```
     /// # use rustacuda::*;
@@ -228,7 +228,7 @@ impl Stream {
     /// complete. Synchronization is performed on the device, if possible. The
     /// event may originate from different context or device than the stream.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::quick_init;
@@ -302,7 +302,7 @@ impl Stream {
     /// Destroying a stream can return errors from previous asynchronous work. This function
     /// destroys the given stream and returns the error and the un-destroyed stream on failure.
     ///
-    /// # Example:
+    /// # Example
     ///
     /// ```
     /// # use rustacuda::*;


### PR DESCRIPTION
I've noticed that the CI have a problem with the command `cargo clippy --all -- -D warnings` (CLIPPY=yes).
The problem as seen in https://travis-ci.org/bheisler/RustaCUDA/jobs/630513201#L349 was some warning arose from clippy:

- `clippy::needless-doctest-main`
- `mem::uninitialized` is now deprecated in favour of `mem::MaybeUninit`
- `clippy::missing-safety-doc`

So I've made this pull request to fix all this problem. The solutions used are:

- Remove the needless `fn main() {}` from all the documentation
- Replace `std::mem::uninitialized()` with `std::mem::MaybeUninit::uninit().assume_init()`
- Fix the wrong `/// # Safety:` comment removing the colon ( `/// # Safety` )
- Write the `/// # Safety` for 4 unsafe function really missing it

PS: I have not opened an issue given the nature of the problem, strictly linked to the way in which continuous integration has been programmed.