### PR TITLE
Add support for getting the UUID of a device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Device::uuid` function, which returns the UUID of a device.
+
+### Fixed
+- Upgraded `cuda-sys` 0.2 to `cuda-driver-sys` 0.3.
 
 ## [0.1.2] - February 29, 2019
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "bheisler/RustaCUDA" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cuda-sys = "0.2"
+cuda-driver-sys = "0.3"
 bitflags = "1.2"
 rustacuda_derive = { version = "0.1.2", path = "rustacuda_derive" }
 rustacuda_core = { version = "0.1.2", path = "rustacuda_core" }

--- a/src/device.rs
+++ b/src/device.rs
@@ -328,6 +328,29 @@ impl Device {
         }
     }
 
+    /// Returns the UUID of this device.
+    ///
+    /// # Example
+    /// ```
+    /// # use rustacuda::*;
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// # init(CudaFlags::empty())?;
+    /// use rustacuda::device::Device;
+    /// let device = Device::get_device(0)?;
+    /// println!("Device UUID: {}", device.uuid()?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn uuid(self) -> CudaResult<[u8; 16]> {
+        unsafe {
+            let mut cu_uuid = CUuuid { bytes: [0i8; 16] };
+            cuDeviceGetUuid(&mut cu_uuid, self.device).to_result()?;
+            let uuid: [u8; 16] = ::std::mem::transmute(cu_uuid.bytes);
+            Ok(uuid)
+        }
+    }
+
     /// Returns information about this device.
     ///
     /// # Example

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,7 +1,7 @@
 //! Functions and types for enumerating CUDA devices and retrieving information about them.
 
 use crate::error::{CudaResult, ToResult};
-use cuda_sys::cuda::*;
+use cuda_driver_sys::*;
 use std::ffi::CStr;
 use std::ops::Range;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@
 //! RustaCUDA) can fail. Even those functions which have no normal failure conditions can return
 //! errors related to previous asynchronous launches.
 
-use cuda_sys::cuda::{self, cudaError_t};
+use cuda_driver_sys::{cuGetErrorString, cudaError_enum};
 use std::error::Error;
 use std::ffi::CStr;
 use std::fmt;
@@ -96,7 +96,7 @@ impl fmt::Display for CudaError {
                 let value = other as u32;
                 let mut ptr: *const c_char = ptr::null();
                 unsafe {
-                    cuda::cuGetErrorString(mem::transmute(value), &mut ptr as *mut *const c_char)
+                    cuGetErrorString(mem::transmute(value), &mut ptr as *mut *const c_char)
                         .to_result()
                         .map_err(|_| fmt::Error)?;
                     let cstr = CStr::from_ptr(ptr);
@@ -119,91 +119,99 @@ pub type DropResult<T> = Result<(), (CudaError, T)>;
 pub(crate) trait ToResult {
     fn to_result(self) -> CudaResult<()>;
 }
-impl ToResult for cudaError_t {
+impl ToResult for cudaError_enum {
     fn to_result(self) -> CudaResult<()> {
         match self {
-            cudaError_t::CUDA_SUCCESS => Ok(()),
-            cudaError_t::CUDA_ERROR_INVALID_VALUE => Err(CudaError::InvalidValue),
-            cudaError_t::CUDA_ERROR_OUT_OF_MEMORY => Err(CudaError::OutOfMemory),
-            cudaError_t::CUDA_ERROR_NOT_INITIALIZED => Err(CudaError::NotInitialized),
-            cudaError_t::CUDA_ERROR_DEINITIALIZED => Err(CudaError::Deinitialized),
-            cudaError_t::CUDA_ERROR_PROFILER_DISABLED => Err(CudaError::ProfilerDisabled),
-            cudaError_t::CUDA_ERROR_PROFILER_NOT_INITIALIZED => {
+            cudaError_enum::CUDA_SUCCESS => Ok(()),
+            cudaError_enum::CUDA_ERROR_INVALID_VALUE => Err(CudaError::InvalidValue),
+            cudaError_enum::CUDA_ERROR_OUT_OF_MEMORY => Err(CudaError::OutOfMemory),
+            cudaError_enum::CUDA_ERROR_NOT_INITIALIZED => Err(CudaError::NotInitialized),
+            cudaError_enum::CUDA_ERROR_DEINITIALIZED => Err(CudaError::Deinitialized),
+            cudaError_enum::CUDA_ERROR_PROFILER_DISABLED => Err(CudaError::ProfilerDisabled),
+            cudaError_enum::CUDA_ERROR_PROFILER_NOT_INITIALIZED => {
                 Err(CudaError::ProfilerNotInitialized)
             }
-            cudaError_t::CUDA_ERROR_PROFILER_ALREADY_STARTED => {
+            cudaError_enum::CUDA_ERROR_PROFILER_ALREADY_STARTED => {
                 Err(CudaError::ProfilerAlreadyStarted)
             }
-            cudaError_t::CUDA_ERROR_PROFILER_ALREADY_STOPPED => {
+            cudaError_enum::CUDA_ERROR_PROFILER_ALREADY_STOPPED => {
                 Err(CudaError::ProfilerAlreadyStopped)
             }
-            cudaError_t::CUDA_ERROR_NO_DEVICE => Err(CudaError::NoDevice),
-            cudaError_t::CUDA_ERROR_INVALID_DEVICE => Err(CudaError::InvalidDevice),
-            cudaError_t::CUDA_ERROR_INVALID_IMAGE => Err(CudaError::InvalidImage),
-            cudaError_t::CUDA_ERROR_INVALID_CONTEXT => Err(CudaError::InvalidContext),
-            cudaError_t::CUDA_ERROR_CONTEXT_ALREADY_CURRENT => {
+            cudaError_enum::CUDA_ERROR_NO_DEVICE => Err(CudaError::NoDevice),
+            cudaError_enum::CUDA_ERROR_INVALID_DEVICE => Err(CudaError::InvalidDevice),
+            cudaError_enum::CUDA_ERROR_INVALID_IMAGE => Err(CudaError::InvalidImage),
+            cudaError_enum::CUDA_ERROR_INVALID_CONTEXT => Err(CudaError::InvalidContext),
+            cudaError_enum::CUDA_ERROR_CONTEXT_ALREADY_CURRENT => {
                 Err(CudaError::ContextAlreadyCurrent)
             }
-            cudaError_t::CUDA_ERROR_MAP_FAILED => Err(CudaError::MapFailed),
-            cudaError_t::CUDA_ERROR_UNMAP_FAILED => Err(CudaError::UnmapFailed),
-            cudaError_t::CUDA_ERROR_ARRAY_IS_MAPPED => Err(CudaError::ArrayIsMapped),
-            cudaError_t::CUDA_ERROR_ALREADY_MAPPED => Err(CudaError::AlreadyMapped),
-            cudaError_t::CUDA_ERROR_NO_BINARY_FOR_GPU => Err(CudaError::NoBinaryForGpu),
-            cudaError_t::CUDA_ERROR_ALREADY_ACQUIRED => Err(CudaError::AlreadyAcquired),
-            cudaError_t::CUDA_ERROR_NOT_MAPPED => Err(CudaError::NotMapped),
-            cudaError_t::CUDA_ERROR_NOT_MAPPED_AS_ARRAY => Err(CudaError::NotMappedAsArray),
-            cudaError_t::CUDA_ERROR_NOT_MAPPED_AS_POINTER => Err(CudaError::NotMappedAsPointer),
-            cudaError_t::CUDA_ERROR_ECC_UNCORRECTABLE => Err(CudaError::EccUncorrectable),
-            cudaError_t::CUDA_ERROR_UNSUPPORTED_LIMIT => Err(CudaError::UnsupportedLimit),
-            cudaError_t::CUDA_ERROR_CONTEXT_ALREADY_IN_USE => Err(CudaError::ContextAlreadyInUse),
-            cudaError_t::CUDA_ERROR_PEER_ACCESS_UNSUPPORTED => {
+            cudaError_enum::CUDA_ERROR_MAP_FAILED => Err(CudaError::MapFailed),
+            cudaError_enum::CUDA_ERROR_UNMAP_FAILED => Err(CudaError::UnmapFailed),
+            cudaError_enum::CUDA_ERROR_ARRAY_IS_MAPPED => Err(CudaError::ArrayIsMapped),
+            cudaError_enum::CUDA_ERROR_ALREADY_MAPPED => Err(CudaError::AlreadyMapped),
+            cudaError_enum::CUDA_ERROR_NO_BINARY_FOR_GPU => Err(CudaError::NoBinaryForGpu),
+            cudaError_enum::CUDA_ERROR_ALREADY_ACQUIRED => Err(CudaError::AlreadyAcquired),
+            cudaError_enum::CUDA_ERROR_NOT_MAPPED => Err(CudaError::NotMapped),
+            cudaError_enum::CUDA_ERROR_NOT_MAPPED_AS_ARRAY => Err(CudaError::NotMappedAsArray),
+            cudaError_enum::CUDA_ERROR_NOT_MAPPED_AS_POINTER => Err(CudaError::NotMappedAsPointer),
+            cudaError_enum::CUDA_ERROR_ECC_UNCORRECTABLE => Err(CudaError::EccUncorrectable),
+            cudaError_enum::CUDA_ERROR_UNSUPPORTED_LIMIT => Err(CudaError::UnsupportedLimit),
+            cudaError_enum::CUDA_ERROR_CONTEXT_ALREADY_IN_USE => {
+                Err(CudaError::ContextAlreadyInUse)
+            }
+            cudaError_enum::CUDA_ERROR_PEER_ACCESS_UNSUPPORTED => {
                 Err(CudaError::PeerAccessUnsupported)
             }
-            cudaError_t::CUDA_ERROR_INVALID_PTX => Err(CudaError::InvalidPtx),
-            cudaError_t::CUDA_ERROR_INVALID_GRAPHICS_CONTEXT => {
+            cudaError_enum::CUDA_ERROR_INVALID_PTX => Err(CudaError::InvalidPtx),
+            cudaError_enum::CUDA_ERROR_INVALID_GRAPHICS_CONTEXT => {
                 Err(CudaError::InvalidGraphicsContext)
             }
-            cudaError_t::CUDA_ERROR_NVLINK_UNCORRECTABLE => Err(CudaError::NvlinkUncorrectable),
-            cudaError_t::CUDA_ERROR_INVALID_SOURCE => Err(CudaError::InvalidSouce),
-            cudaError_t::CUDA_ERROR_FILE_NOT_FOUND => Err(CudaError::FileNotFound),
-            cudaError_t::CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND => {
+            cudaError_enum::CUDA_ERROR_NVLINK_UNCORRECTABLE => Err(CudaError::NvlinkUncorrectable),
+            cudaError_enum::CUDA_ERROR_INVALID_SOURCE => Err(CudaError::InvalidSouce),
+            cudaError_enum::CUDA_ERROR_FILE_NOT_FOUND => Err(CudaError::FileNotFound),
+            cudaError_enum::CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND => {
                 Err(CudaError::SharedObjectSymbolNotFound)
             }
-            cudaError_t::CUDA_ERROR_SHARED_OBJECT_INIT_FAILED => {
+            cudaError_enum::CUDA_ERROR_SHARED_OBJECT_INIT_FAILED => {
                 Err(CudaError::SharedObjectInitFailed)
             }
-            cudaError_t::CUDA_ERROR_OPERATING_SYSTEM => Err(CudaError::OperatingSystemError),
-            cudaError_t::CUDA_ERROR_INVALID_HANDLE => Err(CudaError::InvalidHandle),
-            cudaError_t::CUDA_ERROR_NOT_FOUND => Err(CudaError::NotFound),
-            cudaError_t::CUDA_ERROR_NOT_READY => Err(CudaError::NotReady),
-            cudaError_t::CUDA_ERROR_ILLEGAL_ADDRESS => Err(CudaError::IllegalAddress),
-            cudaError_t::CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES => Err(CudaError::LaunchOutOfResources),
-            cudaError_t::CUDA_ERROR_LAUNCH_TIMEOUT => Err(CudaError::LaunchTimeout),
-            cudaError_t::CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING => {
+            cudaError_enum::CUDA_ERROR_OPERATING_SYSTEM => Err(CudaError::OperatingSystemError),
+            cudaError_enum::CUDA_ERROR_INVALID_HANDLE => Err(CudaError::InvalidHandle),
+            cudaError_enum::CUDA_ERROR_NOT_FOUND => Err(CudaError::NotFound),
+            cudaError_enum::CUDA_ERROR_NOT_READY => Err(CudaError::NotReady),
+            cudaError_enum::CUDA_ERROR_ILLEGAL_ADDRESS => Err(CudaError::IllegalAddress),
+            cudaError_enum::CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES => {
+                Err(CudaError::LaunchOutOfResources)
+            }
+            cudaError_enum::CUDA_ERROR_LAUNCH_TIMEOUT => Err(CudaError::LaunchTimeout),
+            cudaError_enum::CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING => {
                 Err(CudaError::LaunchIncompatibleTexturing)
             }
-            cudaError_t::CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED => {
+            cudaError_enum::CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED => {
                 Err(CudaError::PeerAccessAlreadyEnabled)
             }
-            cudaError_t::CUDA_ERROR_PEER_ACCESS_NOT_ENABLED => Err(CudaError::PeerAccessNotEnabled),
-            cudaError_t::CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE => Err(CudaError::PrimaryContextActive),
-            cudaError_t::CUDA_ERROR_CONTEXT_IS_DESTROYED => Err(CudaError::ContextIsDestroyed),
-            cudaError_t::CUDA_ERROR_ASSERT => Err(CudaError::AssertError),
-            cudaError_t::CUDA_ERROR_TOO_MANY_PEERS => Err(CudaError::TooManyPeers),
-            cudaError_t::CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED => {
+            cudaError_enum::CUDA_ERROR_PEER_ACCESS_NOT_ENABLED => {
+                Err(CudaError::PeerAccessNotEnabled)
+            }
+            cudaError_enum::CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE => {
+                Err(CudaError::PrimaryContextActive)
+            }
+            cudaError_enum::CUDA_ERROR_CONTEXT_IS_DESTROYED => Err(CudaError::ContextIsDestroyed),
+            cudaError_enum::CUDA_ERROR_ASSERT => Err(CudaError::AssertError),
+            cudaError_enum::CUDA_ERROR_TOO_MANY_PEERS => Err(CudaError::TooManyPeers),
+            cudaError_enum::CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED => {
                 Err(CudaError::HostMemoryAlreadyRegistered)
             }
-            cudaError_t::CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED => {
+            cudaError_enum::CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED => {
                 Err(CudaError::HostMemoryNotRegistered)
             }
-            cudaError_t::CUDA_ERROR_HARDWARE_STACK_ERROR => Err(CudaError::HardwareStackError),
-            cudaError_t::CUDA_ERROR_ILLEGAL_INSTRUCTION => Err(CudaError::IllegalInstruction),
-            cudaError_t::CUDA_ERROR_MISALIGNED_ADDRESS => Err(CudaError::MisalignedAddress),
-            cudaError_t::CUDA_ERROR_INVALID_ADDRESS_SPACE => Err(CudaError::InvalidAddressSpace),
-            cudaError_t::CUDA_ERROR_INVALID_PC => Err(CudaError::InvalidProgramCounter),
-            cudaError_t::CUDA_ERROR_LAUNCH_FAILED => Err(CudaError::LaunchFailed),
-            cudaError_t::CUDA_ERROR_NOT_PERMITTED => Err(CudaError::NotPermitted),
-            cudaError_t::CUDA_ERROR_NOT_SUPPORTED => Err(CudaError::NotSupported),
+            cudaError_enum::CUDA_ERROR_HARDWARE_STACK_ERROR => Err(CudaError::HardwareStackError),
+            cudaError_enum::CUDA_ERROR_ILLEGAL_INSTRUCTION => Err(CudaError::IllegalInstruction),
+            cudaError_enum::CUDA_ERROR_MISALIGNED_ADDRESS => Err(CudaError::MisalignedAddress),
+            cudaError_enum::CUDA_ERROR_INVALID_ADDRESS_SPACE => Err(CudaError::InvalidAddressSpace),
+            cudaError_enum::CUDA_ERROR_INVALID_PC => Err(CudaError::InvalidProgramCounter),
+            cudaError_enum::CUDA_ERROR_LAUNCH_FAILED => Err(CudaError::LaunchFailed),
+            cudaError_enum::CUDA_ERROR_NOT_PERMITTED => Err(CudaError::NotPermitted),
+            cudaError_enum::CUDA_ERROR_NOT_SUPPORTED => Err(CudaError::NotSupported),
             _ => Err(CudaError::UnknownError),
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -13,12 +13,12 @@
 // TODO: I'm not sure that these events are/can be safe by Rust's model of safety; they inherently
 // create state which can be mutated even while an immutable borrow is held.
 
-use crate::cuda_sys::cuda::{
+use crate::error::{CudaError, CudaResult, DropResult, ToResult};
+use crate::stream::Stream;
+use cuda_driver_sys::{
     cuEventCreate, cuEventDestroy_v2, cuEventElapsedTime, cuEventQuery, cuEventRecord,
     cuEventSynchronize, CUevent,
 };
-use crate::error::{CudaError, CudaResult, DropResult, ToResult};
-use crate::stream::Stream;
 
 use std::mem;
 use std::ptr;

--- a/src/function.rs
+++ b/src/function.rs
@@ -3,7 +3,7 @@
 use crate::context::{CacheConfig, SharedMemoryConfig};
 use crate::error::{CudaResult, ToResult};
 use crate::module::Module;
-use cuda_sys::cuda::{self, CUfunction};
+use cuda_driver_sys::CUfunction;
 use std::marker::PhantomData;
 use std::mem::transmute;
 
@@ -191,7 +191,7 @@ impl<'a> Function<'a> {
     pub fn get_attribute(&self, attr: FunctionAttribute) -> CudaResult<i32> {
         unsafe {
             let mut val = 0i32;
-            cuda::cuFuncGetAttribute(
+            cuda_driver_sys::cuFuncGetAttribute(
                 &mut val as *mut i32,
                 // This should be safe, as the repr and values of FunctionAttribute should match.
                 ::std::mem::transmute(attr),
@@ -232,7 +232,7 @@ impl<'a> Function<'a> {
     /// # }
     /// ```
     pub fn set_cache_config(&mut self, config: CacheConfig) -> CudaResult<()> {
-        unsafe { cuda::cuFuncSetCacheConfig(self.inner, transmute(config)).to_result() }
+        unsafe { cuda_driver_sys::cuFuncSetCacheConfig(self.inner, transmute(config)).to_result() }
     }
 
     /// Sets the preferred shared memory configuration for this function.
@@ -260,7 +260,7 @@ impl<'a> Function<'a> {
     /// # }
     /// ```
     pub fn set_shared_memory_config(&mut self, cfg: SharedMemoryConfig) -> CudaResult<()> {
-        unsafe { cuda::cuFuncSetSharedMemConfig(self.inner, transmute(cfg)).to_result() }
+        unsafe { cuda_driver_sys::cuFuncSetSharedMemConfig(self.inner, transmute(cfg)).to_result() }
     }
 
     pub(crate) fn to_inner(&self) -> CUfunction {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@
 
 #[macro_use]
 extern crate bitflags;
-extern crate cuda_sys;
+//extern crate cuda_sys;
 extern crate rustacuda_core;
 
 #[allow(unused_imports, clippy::useless_attribute)]
@@ -176,7 +176,7 @@ mod derive_compile_fail;
 use crate::context::{Context, ContextFlags};
 use crate::device::Device;
 use crate::error::{CudaResult, ToResult};
-use cuda_sys::cuda::{cuDriverGetVersion, cuInit};
+use cuda_driver_sys::{cuDriverGetVersion, cuInit};
 
 bitflags! {
     /// Bit flags for initializing the CUDA driver. Currently, no flags are defined,

--- a/src/memory/device/device_buffer.rs
+++ b/src/memory/device/device_buffer.rs
@@ -4,7 +4,6 @@ use crate::memory::malloc::{cuda_free, cuda_malloc};
 use crate::memory::DeviceCopy;
 use crate::memory::DevicePointer;
 use crate::stream::Stream;
-use cuda_sys::cuda;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 
@@ -77,7 +76,7 @@ impl<T> DeviceBuffer<T> {
     pub unsafe fn zeroed(size: usize) -> CudaResult<Self> {
         let ptr = if size > 0 && mem::size_of::<T>() > 0 {
             let mut ptr = cuda_malloc(size)?;
-            cuda::cuMemsetD8_v2(ptr.as_raw_mut() as u64, 0, size * mem::size_of::<T>())
+            cuda_driver_sys::cuMemsetD8_v2(ptr.as_raw_mut() as u64, 0, size * mem::size_of::<T>())
                 .to_result()?;
             ptr
         } else {

--- a/src/memory/device/device_slice.rs
+++ b/src/memory/device/device_slice.rs
@@ -4,7 +4,6 @@ use crate::memory::device::{CopyDestination, DeviceBuffer};
 use crate::memory::DeviceCopy;
 use crate::memory::DevicePointer;
 use crate::stream::Stream;
-use cuda_sys::cuda;
 use std::iter::{ExactSizeIterator, FusedIterator};
 use std::mem;
 use std::ops::{
@@ -447,7 +446,7 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> CopyDestination<I> for 
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
             unsafe {
-                cuda::cuMemcpyHtoD_v2(
+                cuda_driver_sys::cuMemcpyHtoD_v2(
                     self.0.as_mut_ptr() as u64,
                     val.as_ptr() as *const c_void,
                     size,
@@ -467,8 +466,12 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> CopyDestination<I> for 
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
             unsafe {
-                cuda::cuMemcpyDtoH_v2(val.as_mut_ptr() as *mut c_void, self.as_ptr() as u64, size)
-                    .to_result()?
+                cuda_driver_sys::cuMemcpyDtoH_v2(
+                    val.as_mut_ptr() as *mut c_void,
+                    self.as_ptr() as u64,
+                    size,
+                )
+                .to_result()?
             }
         }
         Ok(())
@@ -483,8 +486,12 @@ impl<T: DeviceCopy> CopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
             unsafe {
-                cuda::cuMemcpyDtoD_v2(self.0.as_mut_ptr() as u64, val.as_ptr() as u64, size)
-                    .to_result()?
+                cuda_driver_sys::cuMemcpyDtoD_v2(
+                    self.0.as_mut_ptr() as u64,
+                    val.as_ptr() as u64,
+                    size,
+                )
+                .to_result()?
             }
         }
         Ok(())
@@ -498,8 +505,12 @@ impl<T: DeviceCopy> CopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
             unsafe {
-                cuda::cuMemcpyDtoD_v2(val.as_mut_ptr() as u64, self.as_ptr() as u64, size)
-                    .to_result()?
+                cuda_driver_sys::cuMemcpyDtoD_v2(
+                    val.as_mut_ptr() as u64,
+                    self.as_ptr() as u64,
+                    size,
+                )
+                .to_result()?
             }
         }
         Ok(())
@@ -525,7 +536,7 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> AsyncCopyDestination<I>
         );
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
-            cuda::cuMemcpyHtoDAsync_v2(
+            cuda_driver_sys::cuMemcpyHtoDAsync_v2(
                 self.0.as_mut_ptr() as u64,
                 val.as_ptr() as *const c_void,
                 size,
@@ -544,7 +555,7 @@ impl<T: DeviceCopy, I: AsRef<[T]> + AsMut<[T]> + ?Sized> AsyncCopyDestination<I>
         );
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
-            cuda::cuMemcpyDtoHAsync_v2(
+            cuda_driver_sys::cuMemcpyDtoHAsync_v2(
                 val.as_mut_ptr() as *mut c_void,
                 self.as_ptr() as u64,
                 size,
@@ -563,7 +574,7 @@ impl<T: DeviceCopy> AsyncCopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         );
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
-            cuda::cuMemcpyDtoDAsync_v2(
+            cuda_driver_sys::cuMemcpyDtoDAsync_v2(
                 self.0.as_mut_ptr() as u64,
                 val.as_ptr() as u64,
                 size,
@@ -581,7 +592,7 @@ impl<T: DeviceCopy> AsyncCopyDestination<DeviceSlice<T>> for DeviceSlice<T> {
         );
         let size = mem::size_of::<T>() * self.len();
         if size != 0 {
-            cuda::cuMemcpyDtoDAsync_v2(
+            cuda_driver_sys::cuMemcpyDtoDAsync_v2(
                 val.as_mut_ptr() as u64,
                 self.as_ptr() as u64,
                 size,

--- a/src/memory/malloc.rs
+++ b/src/memory/malloc.rs
@@ -2,7 +2,6 @@ use super::DeviceCopy;
 use crate::error::*;
 use crate::memory::DevicePointer;
 use crate::memory::UnifiedPointer;
-use cuda_sys::cuda;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
@@ -45,7 +44,7 @@ pub unsafe fn cuda_malloc<T>(count: usize) -> CudaResult<DevicePointer<T>> {
     }
 
     let mut ptr: *mut c_void = ptr::null_mut();
-    cuda::cuMemAlloc_v2(&mut ptr as *mut *mut c_void as *mut u64, size).to_result()?;
+    cuda_driver_sys::cuMemAlloc_v2(&mut ptr as *mut *mut c_void as *mut u64, size).to_result()?;
     let ptr = ptr as *mut T;
     Ok(DevicePointer::wrap(ptr as *mut T))
 }
@@ -90,10 +89,10 @@ pub unsafe fn cuda_malloc_unified<T: DeviceCopy>(count: usize) -> CudaResult<Uni
     }
 
     let mut ptr: *mut c_void = ptr::null_mut();
-    cuda::cuMemAllocManaged(
+    cuda_driver_sys::cuMemAllocManaged(
         &mut ptr as *mut *mut c_void as *mut u64,
         size,
-        cuda::CUmemAttach_flags_enum::CU_MEM_ATTACH_GLOBAL as u32,
+        cuda_driver_sys::CUmemAttach_flags_enum::CU_MEM_ATTACH_GLOBAL as u32,
     )
     .to_result()?;
     let ptr = ptr as *mut T;
@@ -129,7 +128,7 @@ pub unsafe fn cuda_free<T>(mut p: DevicePointer<T>) -> CudaResult<()> {
         return Err(CudaError::InvalidMemoryAllocation);
     }
 
-    cuda::cuMemFree_v2(ptr as u64).to_result()?;
+    cuda_driver_sys::cuMemFree_v2(ptr as u64).to_result()?;
     Ok(())
 }
 
@@ -162,7 +161,7 @@ pub unsafe fn cuda_free_unified<T: DeviceCopy>(mut p: UnifiedPointer<T>) -> Cuda
         return Err(CudaError::InvalidMemoryAllocation);
     }
 
-    cuda::cuMemFree_v2(ptr as u64).to_result()?;
+    cuda_driver_sys::cuMemFree_v2(ptr as u64).to_result()?;
     Ok(())
 }
 
@@ -204,7 +203,7 @@ pub unsafe fn cuda_malloc_locked<T>(count: usize) -> CudaResult<*mut T> {
     }
 
     let mut ptr: *mut c_void = ptr::null_mut();
-    cuda::cuMemAllocHost_v2(&mut ptr as *mut *mut c_void, size).to_result()?;
+    cuda_driver_sys::cuMemAllocHost_v2(&mut ptr as *mut *mut c_void, size).to_result()?;
     let ptr = ptr as *mut T;
     Ok(ptr as *mut T)
 }
@@ -237,7 +236,7 @@ pub unsafe fn cuda_free_locked<T>(ptr: *mut T) -> CudaResult<()> {
         return Err(CudaError::InvalidMemoryAllocation);
     }
 
-    cuda::cuMemFreeHost(ptr as *mut c_void).to_result()?;
+    cuda_driver_sys::cuMemFreeHost(ptr as *mut c_void).to_result()?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR consists of two independent commits, the first one is the upgrade to `cuda-driver-sys` 0.3, the second one is the actual implementation API for getting the UUID.

Let me know if you'd prefer to have two separate PR, having it in a single one was just quicker for me as I had this branch already available.

Closes #55.