### PR TITLE
Add cooperative kernel launch API

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -293,6 +293,38 @@ impl Stream {
         .to_result()
     }
 
+    // Hidden implementation detail function. Highly unsafe. Use the `launch_cooperative!` macro instead.
+    #[doc(hidden)]
+    pub unsafe fn launch_cooperative<G, B>(
+        &self,
+        func: &Function,
+        grid_size: G,
+        block_size: B,
+        shared_mem_bytes: u32,
+        args: &[*mut c_void],
+    ) -> CudaResult<()>
+    where
+        G: Into<GridSize>,
+        B: Into<BlockSize>,
+    {
+        let grid_size: GridSize = grid_size.into();
+        let block_size: BlockSize = block_size.into();
+
+        cuda_driver_sys::cuLaunchCooperativeKernel(
+            func.to_inner(),
+            grid_size.x,
+            grid_size.y,
+            grid_size.z,
+            block_size.x,
+            block_size.y,
+            block_size.z,
+            shared_mem_bytes,
+            self.inner,
+            args.as_ptr() as *mut _,
+        )
+        .to_result()
+    }
+
     // Get the inner `CUstream` from the `Stream`.
     //
     // Necessary for certain CUDA functions outside of this


### PR DESCRIPTION
Pascal and newer devices support cooperative groups. These groups enable kernels to, e.g., globally synchronize the grid without terminating the kernel.

A special function `cuLaunchCooperativeKernel` was added to CUDA 9.0 to launch a cooperative group. This PR adds this launch API to RustaCUDA.

Example:
```rust
unsafe { launch_cooperative!( kernel<<<grid, block>>>() ).unwrap() };
```

See the [CUDA documentation](https://docs.nvidia.com/cuda/archive/10.2/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1g06d753134145c4584c0c62525c1894cb) and [this Nvidia Developer blog post](https://developer.nvidia.com/blog/cooperative-groups/) for more information.