### PR TITLE
Correct automatic in_line from rustdoc

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -5,6 +5,7 @@
 
 pub use crate::context::{Context, ContextFlags};
 pub use crate::device::Device;
+#[doc(no_inline)]
 pub use crate::memory::{CopyDestination, DeviceBuffer, UnifiedBuffer};
 pub use crate::module::Module;
 pub use crate::stream::{Stream, StreamFlags};


### PR DESCRIPTION
Repairs #33 

The explanation seems to be at the end of the [rustdoc section](https://doc.rust-lang.org/rustdoc/the-doc-attribute.html#docno_inlinedocinline), saying that rustdoc eagerly tried to inline docs. 