### PR TITLE
Fix compile error on aarch64/arm architectures (resolves #65)

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -4,6 +4,7 @@ use crate::error::{CudaResult, ToResult};
 use cuda_driver_sys::*;
 use std::ffi::CStr;
 use std::ops::Range;
+use std::os::raw::c_char;
 
 /// All supported device attributes for [Device::get_attribute](struct.Device.html#method.get_attribute)
 #[repr(u32)]
@@ -373,7 +374,9 @@ impl Device {
     /// ```
     pub fn uuid(self) -> CudaResult<[u8; 16]> {
         unsafe {
-            let mut cu_uuid = CUuuid { bytes: [0i8; 16] };
+            let mut cu_uuid = CUuuid {
+                bytes: [0usize as c_char; 16],
+            };
             cuDeviceGetUuid(&mut cu_uuid, self.device).to_result()?;
             let uuid: [u8; 16] = ::std::mem::transmute(cu_uuid.bytes);
             Ok(uuid)


### PR DESCRIPTION
This patch fixes the compile error in issue #65. The compile error was caused by this line.

```rust
let mut cu_uuid = CUuuid { bytes: [0i8; 16] };
```

The `CUuuid` accepts an `[c_char; 16]` array, where the type alias `c_char` depends on architecture. The PR replaces it with `bytes: [0usize as c_char; 16]`.
